### PR TITLE
Panic if the bee isn't found

### DIFF
--- a/bees/descriptors.go
+++ b/bees/descriptors.go
@@ -53,7 +53,11 @@ type BeeOptionDescriptor struct {
 
 // Returns the ActionDescriptor matching an action.
 func GetActionDescriptor(action *Action) ActionDescriptor {
-	factory := (*GetFactory((*GetBee(action.Bee)).Namespace()))
+	bee := GetBee(action.Bee)
+	if bee == nil {
+		panic("Bee " + action.Bee + " not registered")
+	}
+	factory := (*GetFactory((*bee).Namespace()))
 	for _, ac := range factory.Actions() {
 		if ac.Name == action.Name {
 			return ac
@@ -65,7 +69,11 @@ func GetActionDescriptor(action *Action) ActionDescriptor {
 
 // Returns the EventDescriptor matching an event.
 func GetEventDescriptor(event *Event) EventDescriptor {
-	factory := (*GetFactory((*GetBee(event.Bee)).Namespace()))
+	bee := GetBee(event.Bee)
+	if bee == nil {
+		panic("Bee " + event.Bee + " not registered")
+	}
+	factory := (*GetFactory((*bee).Namespace()))
 	for _, ev := range factory.Events() {
 		if ev.Name == event.Name {
 			return ev


### PR DESCRIPTION
Gives us a better error than dereferencing nil:

```
Fatal chain event: runtime error: invalid memory address or nil pointer dereference
```

versus:

```
Fatal chain event: Bee this-bee-name-is-wrong not registered
```

Mistyping the action's bee name in a recipe will cause this, like:

```
   "Chains":[
      {
         "Name": "Timer",
         "Description": "Alerts you at the right time",
         "Event":{
            "Bee":"cronbee",
            "Name":"time_event"
         },
         "Elements":[
            {
               "Action":{
                  "Bee":"this-bee-name-is-wrong",
                  "Name":"send",
                  "Options":[
                     {
                        "Name":"text",
                        "Value":"Cuckoo!"
                     }
                  ]
               }
            }
         ]
      }
   ]
```