### PR TITLE
Add the Telegram chat and user ID to the event

### DIFF
--- a/bees/telegrambee/telegrambee.go
+++ b/bees/telegrambee/telegrambee.go
@@ -92,6 +92,16 @@ func (mod *TelegramBee) Run(eventChan chan bees.Event) {
 					Type:  "string",
 					Value: update.Message.Text,
 				},
+				bees.Placeholder{
+					Name:  "chatID",
+					Type:  "string",
+					Value: strconv.FormatInt(update.Message.Chat.ID, 10),
+				},
+				bees.Placeholder{
+					Name:  "userID",
+					Type:  "string",
+					Value: strconv.Itoa(update.Message.From.ID),
+				},
 			},
 		}
 		eventChan <- ev

--- a/bees/telegrambee/telegrambeefactory.go
+++ b/bees/telegrambee/telegrambeefactory.go
@@ -108,10 +108,20 @@ func (factory *TelegramBeeFactory) Events() []bees.EventDescriptor {
 					Name:        "text",
 					Description: "The message that was received",
 					Type:        "string",
+				}, bees.PlaceholderDescriptor{
+					Name:        "chatID",
+					Description: "Telegram's chat ID",
+					Type:        "string",
+				},
+				bees.PlaceholderDescriptor{
+					Name:        "userID",
+					Description: "User ID  sending the message",
+					Type:        "string",
 				},
 			},
 		},
 	}
+
 	return events
 }
 


### PR DESCRIPTION
Adding those we can easily filter by user or chat ID.
Chat ID and User ID are sent as strings so we can use string filters here.