### PR TITLE
Add url parameter to Twitter events

### DIFF
--- a/bees/twitterbee/twitterbee.go
+++ b/bees/twitterbee/twitterbee.go
@@ -171,6 +171,11 @@ func (mod *TwitterBee) handleStreamEvent(item interface{}) {
 					Type:  "string",
 					Value: status.Text,
 				},
+				{
+					Name:  "url",
+					Type:  "url",
+					Value: "https://twitter.com/statuses/" + status.IdStr,
+				},
 			},
 		}
 
@@ -214,6 +219,11 @@ func (mod *TwitterBee) handleStreamEvent(item interface{}) {
 					Name:  "text",
 					Type:  "string",
 					Value: status.TargetObject.Text,
+				},
+				{
+					Name:  "url",
+					Type:  "url",
+					Value: "https://twitter.com/statuses/" + status.TargetObject.IdStr,
 				},
 			},
 		}

--- a/bees/twitterbee/twitterbeefactory.go
+++ b/bees/twitterbee/twitterbeefactory.go
@@ -168,6 +168,11 @@ func (factory *TwitterBeeFactory) Events() []bees.EventDescriptor {
 					Description: "text content of the tweet",
 					Type:        "string",
 				},
+				{
+					Name:        "url",
+					Description: "URL of the tweet",
+					Type:        "url",
+				},
 			},
 		},
 		{
@@ -184,6 +189,11 @@ func (factory *TwitterBeeFactory) Events() []bees.EventDescriptor {
 					Name:        "text",
 					Description: "text content of the tweet",
 					Type:        "string",
+				},
+				{
+					Name:        "url",
+					Description: "URL of the tweet",
+					Type:        "url",
 				},
 			},
 		},
@@ -202,6 +212,11 @@ func (factory *TwitterBeeFactory) Events() []bees.EventDescriptor {
 					Description: "text content of the mention",
 					Type:        "string",
 				},
+				{
+					Name:        "url",
+					Description: "URL of the mention",
+					Type:        "url",
+				},
 			},
 		},
 		{
@@ -218,6 +233,11 @@ func (factory *TwitterBeeFactory) Events() []bees.EventDescriptor {
 					Name:        "text",
 					Description: "Text of the retweeted tweet",
 					Type:        "string",
+				},
+				{
+					Name:        "url",
+					Description: "URL of the retweeted tweet",
+					Type:        "url",
 				},
 			},
 		},
@@ -236,6 +256,11 @@ func (factory *TwitterBeeFactory) Events() []bees.EventDescriptor {
 					Description: "Text of the retweeted tweet",
 					Type:        "string",
 				},
+				{
+					Name:        "url",
+					Description: "URL of the retweeted tweet",
+					Type:        "url",
+				},
 			},
 		},
 		{
@@ -252,6 +277,11 @@ func (factory *TwitterBeeFactory) Events() []bees.EventDescriptor {
 					Name:        "text",
 					Description: "Text of the liked tweet",
 					Type:        "string",
+				},
+				{
+					Name:        "url",
+					Description: "URL of the liked tweet",
+					Type:        "url",
 				},
 			},
 		},
@@ -270,6 +300,11 @@ func (factory *TwitterBeeFactory) Events() []bees.EventDescriptor {
 					Description: "Text of the liked tweet",
 					Type:        "string",
 				},
+				{
+					Name:        "url",
+					Description: "URL of the liked tweet",
+					Type:        "url",
+				},
 			},
 		},
 		{
@@ -287,6 +322,11 @@ func (factory *TwitterBeeFactory) Events() []bees.EventDescriptor {
 					Description: "Text of the unliked tweet",
 					Type:        "string",
 				},
+				{
+					Name:        "url",
+					Description: "URL of the unliked tweet",
+					Type:        "url",
+				},
 			},
 		},
 		{
@@ -303,6 +343,11 @@ func (factory *TwitterBeeFactory) Events() []bees.EventDescriptor {
 					Name:        "text",
 					Description: "Text of the liked tweet",
 					Type:        "string",
+				},
+				{
+					Name:        "url",
+					Description: "URL of the liked tweet",
+					Type:        "url",
 				},
 			},
 		},


### PR DESCRIPTION
Example log output:

INFO[1566] Event received: Twittertest / tweet - is triggered whenever someone you follow tweets 
INFO[1566] 	Options: {username string mcclure111}       
INFO[1566] 	Options: {text string RT @tweegeemee: 170213_063132_b.clj https://t.co/6XDuJuYtWQ #ProceduralArt #generative https://t.co/7kgwYxDg8G} 
INFO[1566] 	Options: {url string https://twitter.com/statuses/831266508819030019} 
