### PR TITLE
Fixed the readme for the SlackBee

### DIFF
--- a/bees/slackbee/README.md
+++ b/bees/slackbee/README.md
@@ -23,7 +23,8 @@ The [Slack](https://slack.com) bee can send and listen to messages in a Slack ch
          }
       ]
    }
-]```
+]
+```
 
 **apiKey**: Slack API Key. You can get one from https://api.slack.com/docs/oauth-test-tokens.
 


### PR DESCRIPTION
The first code block on the slackbee readme didn't terminate correctly. Now it does!