### PR TITLE
telegram bee: fix 32 bit issues

### DIFF
--- a/bees/telegrambee/telegrambee.go
+++ b/bees/telegrambee/telegrambee.go
@@ -55,12 +55,12 @@ func (mod *TelegramBee) Action(action bees.Action) []bees.Placeholder {
 		action.Options.Bind("chat_id", &chatID)
 		action.Options.Bind("text", &text)
 
-		cid, err := strconv.Atoi(chatID)
+		cid, err := strconv.ParseInt(chatID, 10, 64)
 		if err != nil {
 			panic("Invalid telegram chat ID")
 		}
 
-		msg := telegram.NewMessage(int64(cid), text)
+		msg := telegram.NewMessage(cid, text)
 		_, err = mod.bot.Send(msg)
 		if err != nil {
 			mod.Logf("Error sending message %v", err)


### PR DESCRIPTION
Yields:

```
strconv.ParseInt: parsing "-1001116947313": value out of range
```

on 32bit architectures.