### PR TITLE
Add support for embedded assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ beehive.conf
 
 # Jetbrains IDEs
 .idea
+
+# Embedded assets
+api/bindata.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,5 @@ notifications:
   email:
     on_success: change
     on_failure: always
+
+install: make get-deps

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+all: embed
+
+submodule:
+	git submodule update --init
+
+noembed: submodule build
+
+generate:
+	go-bindata --pkg api -o api/bindata.go --ignore \\.git assets/... config/...
+
+go-bindata:
+	[ -f $(shell go env GOPATH)/bin/go-bindata ] || go get -u github.com/jteeuwen/go-bindata/go-bindata
+
+embed: submodule go-bindata generate build
+
+build:
+	go build
+
+get-deps:
+	go get -u
+
+clean:
+	rm -f beehive
+.PHONY: clean embed go-bindata get-deps noembed generate submodule build all

--- a/README.md
+++ b/README.md
@@ -25,17 +25,19 @@ Connecting those modules with each other lets you create immensly useful agents.
 
 Make sure you have a working Go environment. See the [install instructions](http://golang.org/doc/install.html).
 
-To install beehive, simply run:
+### From source
+
+The recommended way is to fetch the sources and run make:
 
     go get github.com/muesli/beehive
-
-To compile it from source:
-
     cd $GOPATH/src/github.com/muesli/beehive
-    go get -u
-    go build
+    make
 
-Run ```beehive --help``` to see a full list of options.
+You can build and install the `beehive` binary like other Go binaries out there (`go get -u`)
+but you'll need to make sure beehive can find the assets (images, javascript, css, etc).
+See the Troubleshooting/Notes section for additional details.
+
+Run `beehive --help` to see a full list of options.
 
 ## Configuration
 
@@ -104,10 +106,10 @@ You can find more information on how to configure beehive and examples [in our W
 
 ## Troubleshooting & Notes
 
-The web interface and other resources aren't currently embedded in the binary.
-Beehive tries to find those files in its current working directory, so it's
-currently recommended to start Beehive from within its git repository, if you
-plan to use the web interface.
+The web interface and other resources are embedded in the binary by default.
+When using `make noembed`, Beehive tries to find those files
+in its current working directory, so it's currently recommended to start Beehive from
+within its git repository, if you plan to use the web interface.
 
 Should you still not be able to reach the web interface, check if the ```config```
 directory in the git repository is empty. If that's the case, make sure the

--- a/api/bindata.go
+++ b/api/bindata.go
@@ -1,0 +1,9 @@
+// go-bindata (https://github.com/jteeuwen/go-bindata) stub
+// so beehive works also without embedded assets.
+package api
+
+import "io/ioutil"
+
+func Asset(asset string) ([]byte, error) {
+	return ioutil.ReadFile(asset)
+}


### PR DESCRIPTION
`make embed` creates a beehive binary with embedded assets (js, img, css, etc).

A go-bindata stub (api/bindata.go) was added so embedding assets isn't required,
which could be useful in low memory devices.