### PR TITLE
slack bee: use links for user mentions

### DIFF
--- a/bees/slackbee/slackbee.go
+++ b/bees/slackbee/slackbee.go
@@ -64,6 +64,7 @@ func (mod *SlackBee) Action(action bees.Action) []bees.Placeholder {
 		}
 
 		msgParams := slack.NewPostMessageParameters()
+		msgParams.LinkNames = 1
 		for _, to := range tos {
 			_, _, err := mod.client.PostMessage(to, text, msgParams)
 			if err != nil {


### PR DESCRIPTION
Linking usernames is standard Slack client behaviour so we should
do the same when sending messages.