### PR TITLE
Strip binary by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ go-bindata:
 embed: submodule go-bindata generate build
 
 build:
+	go build --ldflags '-s -w'
+
+debug: submodule go-bindata generate
 	go build
 
 get-deps:


### PR DESCRIPTION
Reduces the binary size considerably (~15 MiB vs ~23 MiB):

```
[9204][rubiojr@octopro] make debug

[9205][rubiojr@octopro] ls -la beehive
-rwxr-xr-x  1 rubiojr  staff  23024756 Apr 19 23:10 beehive

[9205][rubiojr@octopro] make

[9205][rubiojr@octopro] ls -la beehive
-rwxr-xr-x  1 rubiojr  staff  15413708 Apr 19 23:11 beehive
```

Should we do this by default?