### PR TITLE
renames event in fsnotifybee

### DIFF
--- a/bees/fsnotifybee/fsnotifybee.go
+++ b/bees/fsnotifybee/fsnotifybee.go
@@ -64,7 +64,7 @@ func (mod *FSNotifyBee) ReloadOptions(options bees.BeeOptions) {
 func sendEvent(bee, etype, path string, eventChan chan bees.Event) {
 	event := bees.Event{
 		Bee:  bee,
-		Name: "event",
+		Name: "fsevent",
 		Options: []bees.Placeholder{
 			{
 				Name:  "type",


### PR DESCRIPTION
When creating a chain triggered by an fsnotify event I was having an issue where none of the chains were being triggered. Dug into it some and found that in execChains the name of the triggered event and the name of the chain's event were not matching up. Looks like it was a mismatch between the event name in fsnotifybee and fsnotifybeefactory. Changing the names to match fixed this. 