### PR TITLE
WIP: Add HorizonBoxBee

### DIFF
--- a/bees/horizonboxbee/horizonboxbee.go
+++ b/bees/horizonboxbee/horizonboxbee.go
@@ -41,6 +41,7 @@ type HorizonBoxBee struct {
 	address  string
 	user     string
 	password string
+	interval int
 
 	State     HorizonBoxBeeState
 	eventChan chan bees.Event
@@ -140,7 +141,7 @@ func (mod *HorizonBoxBee) Run(cin chan bees.Event) {
 		case <-mod.SigChan:
 			return
 
-		case <-time.After(time.Duration(10 * time.Second)):
+		case <-time.After(time.Duration(mod.interval) * time.Second):
 			mod.poll()
 		}
 	}
@@ -158,4 +159,5 @@ func (mod *HorizonBoxBee) ReloadOptions(options bees.BeeOptions) {
 	options.Bind("address", &mod.address)
 	options.Bind("user", &mod.user)
 	options.Bind("password", &mod.password)
+	options.Bind("interval", &mod.interval)
 }

--- a/bees/horizonboxbee/horizonboxbee.go
+++ b/bees/horizonboxbee/horizonboxbee.go
@@ -1,0 +1,161 @@
+/*
+ *    Copyright (C) 2017 Dominik Schmidt
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published
+ *    by the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    Authors:
+ *      Dominik Schmidt <dev@dominik-schmidt.de>
+ */
+
+package horizonboxbee
+
+import (
+	"github.com/PuerkitoBio/goquery"
+	"github.com/muesli/beehive/bees"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type HorizonBoxBeeState struct {
+	online bool
+	ip     string
+}
+
+type HorizonBoxBee struct {
+	bees.Bee
+
+	address  string
+	user     string
+	password string
+
+	State     HorizonBoxBeeState
+	eventChan chan bees.Event
+}
+
+func (mod *HorizonBoxBee) poll() {
+	// Form data
+	v := url.Values{}
+	v.Set("username", mod.user)
+	v.Set("password", mod.password)
+	v.Set("page", "login")
+
+	req, err := http.NewRequest("POST", "http://"+mod.address+"/cgi-bin/sendResult.cgi?section=login", strings.NewReader(v.Encode()))
+	if err != nil {
+		mod.LogErrorf("http.NewRequest() error: %v\n", err)
+		return
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+
+	cookieJar, _ := cookiejar.New(nil)
+	c := &http.Client{
+		Jar: cookieJar,
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		mod.LogErrorf("Could not connect to: %s", mod.address, err)
+		return
+	}
+
+	state := HorizonBoxBeeState{}
+	doc, err := goquery.NewDocumentFromResponse(resp)
+	doc.Find("table").Each(func(i int, s *goquery.Selection) {
+		s.Find("tr").Each(func(j int, t *goquery.Selection) {
+			// Unfortunately keys here are translated, thus we rely on the order instead of keys
+			// key := t.Find("td").First().Text()
+			value := t.Find("td").Last().Text()
+
+			switch j {
+			case 8:
+				state.online = false
+				if value == "Enabled" {
+					state.online = true
+				}
+			case 9:
+				state.ip = value
+			}
+		})
+	})
+
+	if mod.State.online != state.online {
+		mod.announceOnlineStateChange(state.online)
+	}
+
+	if mod.State.ip != state.ip {
+		mod.announceIpChange(state.ip)
+	}
+
+	mod.State = state
+}
+
+func (mod *HorizonBoxBee) announceIpChange(ip string) {
+	event := bees.Event{
+		Bee:  mod.Name(),
+		Name: "external_ip_change",
+		Options: []bees.Placeholder{
+			{
+				Name:  "new_external_ip",
+				Type:  "string",
+				Value: ip,
+			},
+		},
+	}
+	mod.eventChan <- event
+}
+
+func (mod *HorizonBoxBee) announceOnlineStateChange(online bool) {
+	event := bees.Event{
+		Bee:  mod.Name(),
+		Name: "connection_status_change",
+		Options: []bees.Placeholder{
+			{
+				Name:  "online",
+				Type:  "bool",
+				Value: online,
+			},
+		},
+	}
+	mod.eventChan <- event
+}
+
+// Run executes the Bee's event loop.
+func (mod *HorizonBoxBee) Run(cin chan bees.Event) {
+	mod.eventChan = cin
+	for {
+		select {
+		case <-mod.SigChan:
+			return
+
+		case <-time.After(time.Duration(10 * time.Second)):
+			mod.poll()
+		}
+	}
+}
+
+// Action triggers the action passed to it.
+func (mod *HorizonBoxBee) Action(action bees.Action) []bees.Placeholder {
+	return []bees.Placeholder{}
+}
+
+// ReloadOptions parses the config options and initializes the Bee.
+func (mod *HorizonBoxBee) ReloadOptions(options bees.BeeOptions) {
+	mod.SetOptions(options)
+
+	options.Bind("address", &mod.address)
+	options.Bind("user", &mod.user)
+	options.Bind("password", &mod.password)
+}

--- a/bees/horizonboxbee/horizonboxbee.go
+++ b/bees/horizonboxbee/horizonboxbee.go
@@ -56,7 +56,7 @@ func (mod *HorizonBoxBee) poll() {
 
 	req, err := http.NewRequest("POST", "http://"+mod.address+"/cgi-bin/sendResult.cgi?section=login", strings.NewReader(v.Encode()))
 	if err != nil {
-		mod.LogErrorf("http.NewRequest() error: %v\n", err)
+		mod.LogErrorf("http.NewRequest() error: %v", err)
 		return
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
@@ -68,7 +68,7 @@ func (mod *HorizonBoxBee) poll() {
 
 	resp, err := c.Do(req)
 	if err != nil {
-		mod.LogErrorf("Could not connect to: %s", mod.address, err)
+		mod.LogErrorf("Could not connect to %s: %v", mod.address, err)
 		return
 	}
 

--- a/bees/horizonboxbee/horizonboxbee.go
+++ b/bees/horizonboxbee/horizonboxbee.go
@@ -147,11 +147,6 @@ func (mod *HorizonBoxBee) Run(cin chan bees.Event) {
 	}
 }
 
-// Action triggers the action passed to it.
-func (mod *HorizonBoxBee) Action(action bees.Action) []bees.Placeholder {
-	return []bees.Placeholder{}
-}
-
 // ReloadOptions parses the config options and initializes the Bee.
 func (mod *HorizonBoxBee) ReloadOptions(options bees.BeeOptions) {
 	mod.SetOptions(options)

--- a/bees/horizonboxbee/horizonboxbee.go
+++ b/bees/horizonboxbee/horizonboxbee.go
@@ -110,7 +110,7 @@ func (mod *HorizonBoxBee) announceIpChange(ip string) {
 		Options: []bees.Placeholder{
 			{
 				Name:  "new_external_ip",
-				Type:  "string",
+				Type:  "address",
 				Value: ip,
 			},
 		},

--- a/bees/horizonboxbee/horizonboxbeefactory.go
+++ b/bees/horizonboxbee/horizonboxbeefactory.go
@@ -118,7 +118,7 @@ func (factory *HorizonBoxBeeFactory) Events() []bees.EventDescriptor {
 				{
 					Name:        "new_external_ip",
 					Description: "The new external ip",
-					Type:        "string",
+					Type:        "address",
 				},
 			},
 		},

--- a/bees/horizonboxbee/horizonboxbeefactory.go
+++ b/bees/horizonboxbee/horizonboxbeefactory.go
@@ -1,0 +1,125 @@
+/*
+ *    Copyright (C) 2017 Dominik Schmidt
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published
+ *    by the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    Authors:
+ *      Dominik Schmidt <dev@dominik-schmidt.de>
+ */
+
+package horizonboxbee
+
+import (
+	"github.com/muesli/beehive/bees"
+)
+
+// HorizonBoxBeeFactory is a factory for HorizonBoxBees.
+type HorizonBoxBeeFactory struct {
+	bees.BeeFactory
+}
+
+// New returns a new Bee instance configured with the supplied options.
+func (factory *HorizonBoxBeeFactory) New(name, description string, options bees.BeeOptions) bees.BeeInterface {
+	bee := HorizonBoxBee{
+		Bee: bees.NewBee(name, factory.ID(), description, options),
+	}
+	bee.ReloadOptions(options)
+
+	return &bee
+}
+
+// ID returns the ID of this Bee.
+func (factory *HorizonBoxBeeFactory) ID() string {
+	return "horizonboxbee"
+}
+
+// Name returns the name of this Bee.
+func (factory *HorizonBoxBeeFactory) Name() string {
+	return "HorizonBox"
+}
+
+// Description returns the description of this Bee.
+func (factory *HorizonBoxBeeFactory) Description() string {
+	return "A module observing the state of a UnityMedia HorizonBox for beehive"
+}
+
+// // Image returns the filename of an image for this Bee.
+// func (factory *HorizonBoxBeeFactory) Image() string {
+// 	return factory.ID() + ".png"
+// }
+
+// LogoColor returns the preferred logo background color (used by the admin interface).
+func (factory *HorizonBoxBeeFactory) LogoColor() string {
+	return "#212727"
+}
+
+func (factory *HorizonBoxBeeFactory) Options() []bees.BeeOptionDescriptor {
+	opts := []bees.BeeOptionDescriptor{
+		{
+			Name:        "address",
+			Description: "Address of the HorizonBox, eg: 192.168.192.1",
+			Type:        "address",
+			Mandatory:   true,
+		},
+		{
+			Name:        "user",
+			Description: "Username to login to the HorizonBox",
+			Type:        "string",
+			Mandatory:   true,
+		},
+		{
+			Name:        "password",
+			Description: "Password to login to the HorizonBox",
+			Type:        "password",
+			Mandatory:   true,
+		},
+	}
+	return opts
+}
+
+// Events describes the available events provided by this Bee.
+func (factory *HorizonBoxBeeFactory) Events() []bees.EventDescriptor {
+	events := []bees.EventDescriptor{
+		{
+			Namespace:   factory.Name(),
+			Name:        "connection_status_change",
+			Description: "The internet connection changed",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "online",
+					Description: "The new connection status",
+					Type:        "bool",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "external_ip_change",
+			Description: "The external ip changed",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "new_external_ip",
+					Description: "The new external ip",
+					Type:        "string",
+				},
+			},
+		},
+	}
+	return events
+}
+
+func init() {
+	f := HorizonBoxBeeFactory{}
+	bees.RegisterFactory(&f)
+}

--- a/bees/horizonboxbee/horizonboxbeefactory.go
+++ b/bees/horizonboxbee/horizonboxbeefactory.go
@@ -51,7 +51,7 @@ func (factory *HorizonBoxBeeFactory) Name() string {
 
 // Description returns the description of this Bee.
 func (factory *HorizonBoxBeeFactory) Description() string {
-	return "A module observing the state of a UnityMedia HorizonBox for beehive"
+	return "A bee observing the state of a UnityMedia HorizonBox"
 }
 
 // // Image returns the filename of an image for this Bee.

--- a/bees/horizonboxbee/horizonboxbeefactory.go
+++ b/bees/horizonboxbee/horizonboxbeefactory.go
@@ -84,6 +84,13 @@ func (factory *HorizonBoxBeeFactory) Options() []bees.BeeOptionDescriptor {
 			Type:        "password",
 			Mandatory:   true,
 		},
+		{
+			Name:        "interval",
+			Description: "State polling interval in seconds",
+			Type:        "int",
+			Default:     60,
+			Mandatory:   true,
+		},
 	}
 	return opts
 }

--- a/hives.go
+++ b/hives.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/muesli/beehive/bees/fsnotifybee"
 	_ "github.com/muesli/beehive/bees/githubbee"
 	_ "github.com/muesli/beehive/bees/gitterbee"
+	_ "github.com/muesli/beehive/bees/horizonboxbee"
 	_ "github.com/muesli/beehive/bees/htmlextractbee"
 	_ "github.com/muesli/beehive/bees/httpbee"
 	_ "github.com/muesli/beehive/bees/huebee"


### PR DESCRIPTION
This PR adds a Bee for noticing online/ip changes on the HorizonBox shipped by UPC/UnityMedia e.g.

Currently the polling is pretty stupid and could instead reuse the existing cookiejar instead of creating new sessions all the time. Also I haven't tested this for very long, thus the PR is marked WIP.