### PR TITLE
Openweathermapbee: Changed owm api library

### DIFF
--- a/bees/openweathermapbee/event.go
+++ b/bees/openweathermapbee/event.go
@@ -23,7 +23,8 @@ package openweathermapbee
 
 import (
 	"github.com/muesli/beehive/bees"
-	owm "github.com/penguwin/openweathermap"
+
+	owm "github.com/briandowns/openweathermap"
 )
 
 // TriggerCurrentWeatherEvent triggers all current weather events

--- a/bees/openweathermapbee/openweathermapbee.go
+++ b/bees/openweathermapbee/openweathermapbee.go
@@ -24,7 +24,8 @@ package openweathermapbee
 
 import (
 	"github.com/muesli/beehive/bees"
-	owm "github.com/penguwin/openweathermap"
+
+	owm "github.com/briandowns/openweathermap"
 )
 
 // OpenweathermapBee is a Bee that can chat with cleverbot


### PR DESCRIPTION
Changed from 'penguwin/openweathermap' to 'briandowns/openweathermap'. See [why](https://github.com/briandowns/openweathermap/pull/56).
According to [this](https://github.com/briandowns/openweathermap/pull/58/). we can now also serve weather forecasts in our openweathermapbee.
I can start working on it if desired ;)
