### PR TITLE
Add CANONICAL_URL env parameter for an container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,5 +17,4 @@ WORKDIR /go/src/github.com/muesli/beehive
 VOLUME /conf
 
 # This form of ENTRYPOINT allows the beehive process to catch signals from the `docker stop` command
-ENTRYPOINT ["beehive", "-config", "/conf/beehive.conf", "-bind", "0.0.0.0:8181", "-canonicalurl", ${CANONICAL_URL}]
-
+ENTRYPOINT beehive -config /conf/beehive.conf -bind 0.0.0.0:8181 -canonicalurl ${CANONICAL_URL}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.8
 
 LABEL authors="Gabriel Alacchi: alacchi.g@gmail.com, Christian Muehlhaeuser: muesli@gmail.com"
 
+ENV CANONICAL_URL=http://localhost:8181
+
 # Expose the application port
 EXPOSE 8181
 
@@ -15,5 +17,5 @@ WORKDIR /go/src/github.com/muesli/beehive
 VOLUME /conf
 
 # This form of ENTRYPOINT allows the beehive process to catch signals from the `docker stop` command
-ENTRYPOINT ["beehive", "-config", "/conf/beehive.conf", "-bind", "0.0.0.0:8181"]
+ENTRYPOINT ["beehive", "-config", "/conf/beehive.conf", "-bind", "0.0.0.0:8181", "-canonicalurl", ${CANONICAL_URL}]
 


### PR DESCRIPTION
In a docker container, canonical url of beehive was not configurable and always act as http://localhost:8181. This pr accepting canonical url from env and passing it to beehive when beehive starting.