### PR TITLE
Alpine based Beehive docker image

### DIFF
--- a/docker/Dockerfile-alpine
+++ b/docker/Dockerfile-alpine
@@ -1,0 +1,20 @@
+FROM golang:1.8-alpine
+
+LABEL authors="Gabriel Alacchi: alacchi.g@gmail.com, Christian Muehlhaeuser: muesli@gmail.com, Henry Wang: henry@wangqiru.com"
+
+# URL has to be set to the URL of Beehive admin interface
+ENV URL=http://localhost:8181
+
+# Install dependencies and beehive
+RUN apk add --no-cache git build-base --no-cache && \
+    go get github.com/muesli/beehive && \
+    rm -rf /var/cache/apk/* &&\ 
+    go get github.com/muesli/beehive
+    
+# Set the working directory for the container
+WORKDIR /go/src/github.com/muesli/beehive
+
+# Expose the application port
+EXPOSE 8181
+
+ENTRYPOINT beehive -config /conf/beehive.conf -bind 0.0.0.0:8181 -canonicalurl ${URL}


### PR DESCRIPTION
Squashed docker image size from 802MB to 523MB.