### PR TITLE
EFABee: Optional parameter for amount of upcoming departures to fetch

### DIFF
--- a/bees/efabee/efabee.go
+++ b/bees/efabee/efabee.go
@@ -46,7 +46,9 @@ func (mod *EFABee) Action(action bees.Action) []bees.Placeholder {
 	switch action.Name {
 	case "departures":
 		stop := ""
+		amount := 3
 		action.Options.Bind("stop", &stop)
+		action.Options.Bind("amount", &amount)
 
 		//FIXME get departures
 		station, err := mod.efa.FindStop(stop)
@@ -56,7 +58,7 @@ func (mod *EFABee) Action(action bees.Action) []bees.Placeholder {
 		}
 		mod.Logf("Selected stop: %s (%d)", station[0].Name, station[0].ID)
 
-		departures, err := station[0].Departures(time.Now(), 3)
+		departures, err := station[0].Departures(time.Now(), amount)
 		if err != nil {
 			mod.Logln("Could not retrieve departure times!")
 			return outs

--- a/bees/efabee/efabeefactory.go
+++ b/bees/efabee/efabeefactory.go
@@ -130,6 +130,12 @@ func (factory *EFABeeFactory) Actions() []bees.ActionDescriptor {
 					Type:        "string",
 					Mandatory:   true,
 				},
+				{
+					Name:        "amount",
+					Description: "The amount of departures you want (Default: 3)",
+					Type:        "int",
+					Mandatory:   false,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Efabee now takes the number of next departures you want to retrieve. The
default amount to fetch is set to 3.