### PR TITLE
Configuration API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -41,6 +41,7 @@ import (
 	"github.com/muesli/beehive/api/resources/actions"
 	"github.com/muesli/beehive/api/resources/bees"
 	"github.com/muesli/beehive/api/resources/chains"
+	"github.com/muesli/beehive/api/resources/config"
 	"github.com/muesli/beehive/api/resources/hives"
 	"github.com/muesli/beehive/api/resources/logs"
 	"github.com/muesli/beehive/app"
@@ -193,6 +194,7 @@ func Run() {
 		&chains.ChainResource{},
 		&actions.ActionResource{},
 		&logs.LogResource{},
+		&config.ConfigResource{},
 	)
 
 	server := &http.Server{Addr: bind, Handler: wsContainer}

--- a/api/resources/bees/bees_delete.go
+++ b/api/resources/bees/bees_delete.go
@@ -23,6 +23,7 @@ package bees
 import (
 	"github.com/emicklei/go-restful"
 	"github.com/muesli/beehive/bees"
+	"github.com/muesli/beehive/cfg"
 	"github.com/muesli/smolder"
 )
 
@@ -55,6 +56,7 @@ func (r *BeeResource) Delete(context smolder.APIContext, request *restful.Reques
 
 	go func() {
 		bees.DeleteBee(bee)
+		cfg.SaveCurrentConfig()
 	}()
 
 	resp.Send(response)

--- a/api/resources/bees/bees_post.go
+++ b/api/resources/bees/bees_post.go
@@ -23,6 +23,7 @@ package bees
 import (
 	"github.com/emicklei/go-restful"
 	"github.com/muesli/beehive/bees"
+	"github.com/muesli/beehive/cfg"
 	"github.com/muesli/smolder"
 )
 
@@ -68,6 +69,7 @@ func (r *BeeResource) Post(context smolder.APIContext, data interface{}, request
 	}
 
 	bee := bees.StartBee(c)
+	cfg.SaveCurrentConfig()
 	resp.AddBee(bee)
 
 	resp.Send(response)

--- a/api/resources/bees/bees_put.go
+++ b/api/resources/bees/bees_put.go
@@ -23,6 +23,7 @@ package bees
 import (
 	"github.com/emicklei/go-restful"
 	"github.com/muesli/beehive/bees"
+	"github.com/muesli/beehive/cfg"
 	"github.com/muesli/smolder"
 )
 
@@ -63,6 +64,7 @@ func (r *BeeResource) Put(context smolder.APIContext, data interface{}, request 
 		(*bee).Stop()
 	}
 
+	cfg.SaveCurrentConfig()
 	resp.AddBee(bee)
 	resp.Send(response)
 }

--- a/api/resources/chains/chains_delete.go
+++ b/api/resources/chains/chains_delete.go
@@ -23,6 +23,7 @@ package chains
 import (
 	"github.com/emicklei/go-restful"
 	"github.com/muesli/beehive/bees"
+	"github.com/muesli/beehive/cfg"
 	"github.com/muesli/smolder"
 )
 
@@ -60,6 +61,7 @@ func (r *ChainResource) Delete(context smolder.APIContext, request *restful.Requ
 
 	if found {
 		bees.SetChains(chains)
+		cfg.SaveCurrentConfig()
 		resp.Send(response)
 	} else {
 		r.NotFound(request, response)

--- a/api/resources/chains/chains_post.go
+++ b/api/resources/chains/chains_post.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/emicklei/go-restful"
 	"github.com/muesli/beehive/bees"
+	"github.com/muesli/beehive/cfg"
 	"github.com/muesli/smolder"
 )
 
@@ -78,6 +79,8 @@ func (r *ChainResource) Post(context smolder.APIContext, data interface{}, reque
 	}
 	chains := append(bees.GetChains(), chain)
 	bees.SetChains(chains)
+
+	cfg.SaveCurrentConfig()
 
 	resp.AddChain(chain)
 	resp.Send(response)

--- a/api/resources/config/config.go
+++ b/api/resources/config/config.go
@@ -1,0 +1,64 @@
+/*
+ *    Copyright (C) 2018 Sergio Rubio
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published
+ *    by the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    Authors:
+ *      Sergio Rubio <sergio@rubio.im>
+ */
+
+package config
+
+import (
+	"github.com/emicklei/go-restful"
+	"github.com/muesli/smolder"
+)
+
+// ChainResource is the resource responsible for /chains
+type ConfigResource struct {
+	smolder.Resource
+}
+
+var (
+	_ smolder.PostSupported = &ConfigResource{}
+	_ smolder.GetSupported  = &ConfigResource{}
+)
+
+// Register this resource with the container to setup all the routes
+func (r *ConfigResource) Register(container *restful.Container, config smolder.APIConfig, context smolder.APIContextFactory) {
+	r.Name = "ConfigResource"
+	r.TypeName = "config"
+	r.Endpoint = "config"
+	r.Doc = "Manage config"
+
+	r.Config = config
+	r.Context = context
+
+	r.Init(container, r)
+}
+
+// Reads returns the model that will be read by POST, PUT & PATCH operations
+func (r *ConfigResource) Reads() interface{} {
+	return &ConfigPostStruct{}
+}
+
+// Returns returns the model that will be returned
+func (r *ConfigResource) Returns() interface{} {
+	return ConfigResponse{}
+}
+
+// Validate checks an incoming request for data errors
+func (r *ConfigResource) Validate(context smolder.APIContext, data interface{}, request *restful.Request) error {
+	return nil
+}

--- a/api/resources/config/config_get.go
+++ b/api/resources/config/config_get.go
@@ -1,0 +1,63 @@
+/*
+ *    Copyright (C) 2019 Sergio Rubio
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published
+ *    by the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    Authors:
+ *      Sergio Rubio <rubiojr@frameos.org>
+ */
+
+package config
+
+import (
+	"github.com/emicklei/go-restful"
+	"github.com/muesli/beehive/bees"
+	"github.com/muesli/beehive/cfg"
+	"github.com/muesli/smolder"
+)
+
+// GetAuthRequired returns true because all requests need authentication
+func (r *ConfigResource) GetAuthRequired() bool {
+	return false
+}
+
+// GetByIDsAuthRequired returns true because all requests need authentication
+func (r *ConfigResource) GetByIDsAuthRequired() bool {
+	return false
+}
+
+// GetDoc returns the description of this API endpoint
+func (r *ConfigResource) GetDoc() string {
+	return "retrieve config"
+}
+
+// GetParams returns the parameters supported by this API endpoint
+func (r *ConfigResource) GetParams() []*restful.Parameter {
+	params := []*restful.Parameter{}
+
+	return params
+}
+
+// Get sends out items matching the query parameters
+func (r *ConfigResource) Get(ctx smolder.APIContext, request *restful.Request, response *restful.Response, params map[string][]string) {
+	resp := ConfigResponse{}
+	resp.Init(ctx)
+
+	config := cfg.GetConfig()
+	config.Bees = bees.BeeConfigs()
+	config.Chains = bees.GetChains()
+	config.Actions = bees.GetActions()
+	resp.Config = config
+	resp.Send(response)
+}

--- a/api/resources/config/config_post.go
+++ b/api/resources/config/config_post.go
@@ -1,5 +1,5 @@
 /*
- *    Copyright (C) 2017 Christian Muehlhaeuser
+ *    Copyright (C) 2019 Sergio Rubio
  *
  *    This program is free software: you can redistribute it and/or modify
  *    it under the terms of the GNU Affero General Public License as published
@@ -15,59 +15,43 @@
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  *    Authors:
- *      Christian Muehlhaeuser <muesli@gmail.com>
+ *      Sergio Rubio <sergio@rubio.im>
  */
 
-package actions
+package config
 
 import (
 	"github.com/emicklei/go-restful"
-	"github.com/muesli/beehive/bees"
 	"github.com/muesli/beehive/cfg"
 	"github.com/muesli/smolder"
 )
 
-// ActionPostStruct holds all values of an incoming POST request
-type ActionPostStruct struct {
-	Action struct {
-		Bee     string            `json:"bee"`
-		Name    string            `json:"name"`
-		Options bees.Placeholders `json:"options"`
-	} `json:"action"`
+// ConfigPostStruct holds all values of an incoming POST request
+type ConfigPostStruct struct {
+	Config struct {
+		Name string `json:"name"`
+	} `json:"config"`
 }
 
 // PostAuthRequired returns true because all requests need authentication
-func (r *ActionResource) PostAuthRequired() bool {
+func (r *ConfigResource) PostAuthRequired() bool {
 	return false
 }
 
 // PostDoc returns the description of this API endpoint
-func (r *ActionResource) PostDoc() string {
-	return "create a new action"
+func (r *ConfigResource) PostDoc() string {
+	return "create a new config"
 }
 
 // PostParams returns the parameters supported by this API endpoint
-func (r *ActionResource) PostParams() []*restful.Parameter {
+func (r *ConfigResource) PostParams() []*restful.Parameter {
 	return nil
 }
 
 // Post processes an incoming POST (create) request
-func (r *ActionResource) Post(context smolder.APIContext, data interface{}, request *restful.Request, response *restful.Response) {
-	resp := ActionResponse{}
-	resp.Init(context)
-
-	pps := data.(*ActionPostStruct)
-	action := bees.Action{
-		ID:      bees.UUID(),
-		Bee:     pps.Action.Bee,
-		Name:    pps.Action.Name,
-		Options: pps.Action.Options,
-	}
-	actions := append(bees.GetActions(), action)
-	bees.SetActions(actions)
-
+func (r *ConfigResource) Post(context smolder.APIContext, data interface{}, request *restful.Request, response *restful.Response) {
 	cfg.SaveCurrentConfig()
-
-	resp.AddAction(&action)
+	resp := ConfigResponse{}
+	resp.Init(context)
 	resp.Send(response)
 }

--- a/api/resources/config/config_response.go
+++ b/api/resources/config/config_response.go
@@ -1,0 +1,50 @@
+/*
+ *    Copyright (C) 2019 Sergio Rubio
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published
+ *    by the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    Authors:
+ *      Sergio Rubio <sergio@rubio.im>
+ */
+
+package config
+
+import (
+	restful "github.com/emicklei/go-restful"
+	"github.com/muesli/beehive/cfg"
+	"github.com/muesli/smolder"
+)
+
+// HiveResponse is the common response to 'hive' requests
+type ConfigResponse struct {
+	smolder.Response
+
+	Config cfg.Config `json:"config,omitempty"`
+}
+
+// Init a new response
+func (r *ConfigResponse) Init(context smolder.APIContext) {
+	r.Parent = r
+	r.Context = context
+}
+
+// Send responds to a request with http.StatusOK
+func (r *ConfigResponse) Send(response *restful.Response) {
+	r.Response.Send(response)
+}
+
+// EmptyResponse returns an empty API response for this endpoint if there's no data to respond with
+func (r *ConfigResponse) EmptyResponse() interface{} {
+	return nil
+}

--- a/app/app.go
+++ b/app/app.go
@@ -35,7 +35,9 @@ type CliFlag struct {
 }
 
 var (
-	appflags []CliFlag
+	appflags    []CliFlag
+	configFile  string
+	versionFlag bool
 )
 
 // AddFlags adds CliFlags to appflags

--- a/beehive.go
+++ b/beehive.go
@@ -24,9 +24,7 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -36,6 +34,7 @@ import (
 
 	"github.com/muesli/beehive/api"
 	"github.com/muesli/beehive/app"
+	"github.com/muesli/beehive/cfg"
 	_ "github.com/muesli/beehive/filters"
 	_ "github.com/muesli/beehive/filters/template"
 
@@ -46,40 +45,6 @@ var (
 	configFile  string
 	versionFlag bool
 )
-
-// Config contains an entire configuration set for Beehive
-type Config struct {
-	Bees    []bees.BeeConfig
-	Actions []bees.Action
-	Chains  []bees.Chain
-}
-
-// Loads chains from config
-func loadConfig() Config {
-	config := Config{}
-
-	j, err := ioutil.ReadFile(configFile)
-	if err == nil {
-		err = json.Unmarshal(j, &config)
-		if err != nil {
-			log.Fatal("Error parsing config file: ", err)
-		}
-	}
-
-	return config
-}
-
-// Saves chains to config
-func saveConfig(c Config) {
-	j, err := json.MarshalIndent(c, "", "  ")
-	if err == nil {
-		err = ioutil.WriteFile(configFile, j, 0644)
-	}
-
-	if err != nil {
-		log.Fatal(err)
-	}
-}
 
 func main() {
 	app.AddFlags([]app.CliFlag{
@@ -112,7 +77,7 @@ func main() {
 	log.Println()
 	log.Println("Beehive is buzzing...")
 
-	config := loadConfig()
+	config := cfg.LoadConfig(configFile)
 
 	// Load actions from config
 	bees.SetActions(config.Actions)
@@ -131,7 +96,7 @@ func main() {
 		abort := false
 		switch s {
 		case syscall.SIGHUP:
-			config = loadConfig()
+			config = cfg.GetConfig()
 			bees.StopBees()
 			bees.SetActions(config.Actions)
 			bees.SetChains(config.Chains)
@@ -156,7 +121,7 @@ func main() {
 	config.Bees = bees.BeeConfigs()
 	config.Chains = bees.GetChains()
 	config.Actions = bees.GetActions()
-	saveConfig(config)
+	cfg.SaveConfig(config)
 }
 
 func init() {

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -3,7 +3,8 @@ package cfg
 import (
 	"encoding/json"
 	"io/ioutil"
-	"log"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/muesli/beehive/bees"
 )
@@ -43,6 +44,7 @@ func SaveConfig(c Config) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	log.Println("Configuration saved")
 }
 
 func SaveCurrentConfig() {

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1,0 +1,58 @@
+package cfg
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+
+	"github.com/muesli/beehive/bees"
+)
+
+var configFile string
+
+// Config contains an entire configuration set for Beehive
+type Config struct {
+	Bees    []bees.BeeConfig
+	Actions []bees.Action
+	Chains  []bees.Chain
+}
+
+// Loads chains from config
+func LoadConfig(file string) Config {
+	configFile = file
+	config := Config{}
+
+	j, err := ioutil.ReadFile(configFile)
+	if err == nil {
+		err = json.Unmarshal(j, &config)
+		if err != nil {
+			log.Fatal("Error parsing config file: ", err)
+		}
+	}
+
+	return config
+}
+
+// Saves chains to config
+func SaveConfig(c Config) {
+	j, err := json.MarshalIndent(c, "", "  ")
+	if err == nil {
+		err = ioutil.WriteFile(configFile, j, 0644)
+	}
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func SaveCurrentConfig() {
+	config := Config{}
+	config.Bees = bees.BeeConfigs()
+	config.Chains = bees.GetChains()
+	config.Actions = bees.GetActions()
+	SaveConfig(config)
+}
+
+func GetConfig() Config {
+	return LoadConfig(configFile)
+}


### PR DESCRIPTION
* Move json config related tasks to its own package (cfg)
* Provides an API to get/set the configuration (`/v1/config` endpoint)
* Saves the config every time we change it, instead of waiting for a graceful
  shutdown. This prevents losing config changes for unclean daemon shutdowns.

One of the current limitations of this approach is that it has been designed
with a single API client in mind, so saving the config isn't safe in a
multi-client environment.
If several clients try to update the config at the same time, only one will
succeed and changes from other clients will be discarded.

I'm not sure how big of a problem that'd be for beehive in reality.