### PR TITLE
Dump the stack to debug fatal chain events

### DIFF
--- a/bees/events.go
+++ b/bees/events.go
@@ -22,6 +22,7 @@
 package bees
 
 import log "github.com/sirupsen/logrus"
+import "runtime/debug"
 
 // An Event describes an event including its parameters.
 type Event struct {
@@ -56,7 +57,7 @@ func handleEvents() {
 		go func() {
 			defer func() {
 				if e := recover(); e != nil {
-					log.Println("Fatal chain event:", e)
+					log.Printf("Fatal chain event: %s %s", e, debug.Stack())
 				}
 			}()
 


### PR DESCRIPTION
Helps debugging fatal errors like:

```
Fatal chain event: runtime error: invalid memory address or nil pointer dereference
```

adding a bit more info and helping to pinpoint where the issue is happening.