### PR TITLE
Fix OSX Build error (goserial fails to compile and find termios.h)

### DIFF
--- a/bees/serialbee/serialbee.go
+++ b/bees/serialbee/serialbee.go
@@ -1,3 +1,8 @@
+// +build !darwin
+
+// FIXME: This bee doesn't build on macOS
+// XXX: https://gist.github.com/prologic/b5fa148410a26f917b4d944b72d847c0
+
 /*
  *    Copyright (C) 2014-2017 Christian Muehlhaeuser
  *

--- a/bees/serialbee/serialbeefactory.go
+++ b/bees/serialbee/serialbeefactory.go
@@ -1,3 +1,8 @@
+// +build !darwin
+
+// FIXME: This bee doesn't build on macOS
+// XXX: https://gist.github.com/prologic/b5fa148410a26f917b4d944b72d847c0
+
 /*
  *    Copyright (C) 2014-2017 Christian Muehlhaeuser
  *

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ github.com/carlosdp/twiliogo v0.0.0-20140102225436-f61c8230fa91 h1:fIflfwVZsOHJD
 github.com/carlosdp/twiliogo v0.0.0-20140102225436-f61c8230fa91/go.mod h1:pAxCBpjl/0JxYZlWGP/Dyi8f/LQSCQD2WAsG/iNzqQ8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/gosx-notifier v0.0.0-20180201035817-e127226297fb h1:6S+TKObz6+Io2c8IOkcbK4Sz7nj6RpEVU7TkvmsZZcw=
 github.com/deckarep/gosx-notifier v0.0.0-20180201035817-e127226297fb/go.mod h1:wf3nKtOnQqCp7kp9xB7hHnNlZ6m3NoiOxjrB9hFRq4Y=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-jsonpointer v0.0.0-20160814072949-ba0abeacc3dc h1:tP7tkU+vIsEOKiK+l/NSLN4uUtkyuxc6hgYpQeCWAeI=

--- a/hives.go
+++ b/hives.go
@@ -49,7 +49,6 @@ import (
 	_ "github.com/muesli/beehive/bees/pushoverbee"
 	_ "github.com/muesli/beehive/bees/rssbee"
 	_ "github.com/muesli/beehive/bees/s3bee"
-	_ "github.com/muesli/beehive/bees/serialbee"
 	_ "github.com/muesli/beehive/bees/simplepushbee"
 	_ "github.com/muesli/beehive/bees/slackbee"
 	_ "github.com/muesli/beehive/bees/socketbee"

--- a/hives_unix.go
+++ b/hives_unix.go
@@ -24,4 +24,5 @@ package main
 
 import (
 	_ "github.com/muesli/beehive/bees/notificationbee"
+	_ "github.com/muesli/beehive/bees/serialbee"
 )


### PR DESCRIPTION
**Test Plan:**

```#!bash
prologic@Jamess-MacBook
Thu Apr 25 13:28:06
~/Contributions/beehive
 (fix_osx_build) 0
$ go build

prologic@Jamess-MacBook
Thu Apr 25 13:28:11
~/Contributions/beehive
 (fix_osx_build) 0
$ ./beehive -version
Beehive 0.0.0 (unknown)
```

This is likely a *temporary* work-around until a better solution is in place. Because `goserial` **should** compile. OS X **does** have a `termios.h` but I can't find the right solution to make `go build` find it.