### PR TITLE
Added goreleaser config and tool to help make releases easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ vendor/
 # Folders
 _obj
 _test
+/dist
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,23 @@
+builds:
+  - 
+    binary: beehive
+    ldflags: -s -w -X main.Version={{ .Version }} -X main.CommitSHA={{ .Commit }}
+sign:
+  artifacts: checksum
+archive:
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ debug: submodule go-bindata generate
 test:
 	go test -v $(shell go list ./... | grep -v vendor/)
 
+release:
+	@./tools/release.sh
+
 clean:
 	rm -f beehive
-.PHONY: clean embed go-bindata noembed generate submodule build all
+
+.PHONY: clean embed go-bindata noembed generate submodule build all release

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+if ! command -v goreleaser; then
+  echo "goreleaser not found"
+  exit 1
+fi
+
+# Get the highest tag number
+VERSION="$(git describe --abbrev=0 --tags)"
+VERSION=${VERSION:-'0.0.0'}
+
+# Get number parts
+MAJOR="${VERSION%%.*}"; VERSION="${VERSION#*.}"
+MINOR="${VERSION%%.*}"; VERSION="${VERSION#*.}"
+PATCH="${VERSION%%.*}"; VERSION="${VERSION#*.}"
+
+# Increase version
+PATCH=$((PATCH+1))
+
+TAG="${1}"
+
+if [ "${TAG}" = "" ]; then
+  TAG="${MAJOR}.${MINOR}.${PATCH}"
+fi
+
+echo "Releasing ${TAG} ..."
+
+git tag -a -s -m "Relase ${TAG}" "${TAG}"
+git push --tags
+goreleaser release --rm-dist


### PR DESCRIPTION
Closes #218 

This now makes tagging, building and publishing new binaries to Github a lot easier.

**To release a new version:**

```#!bash
$ make release
```

To release a specific tagged version:

```#!bash
./tools/release.sh v1.2
```

Be sure to have `GITHUB_TOKEN` in your environment and [goreleaser](https://github.com/goreleaser/goreleaser) installed. Barring any cross-compiling issues this *should* work :)