### PR TITLE
Add stdin as input-parameter to exec-bee

### DIFF
--- a/bees/execbee/execbee.go
+++ b/bees/execbee/execbee.go
@@ -66,9 +66,8 @@ func (mod *ExecBee) Action(action bees.Action) []bees.Placeholder {
 				}
 
 				go func() {
-					mod.Logf("StdIn" + stdin)
-					defer stdinPipe.Close()
 					io.WriteString(stdinPipe, stdin)
+					stdinPipe.Close()
 				}()
 			}
 

--- a/bees/execbee/execbee.go
+++ b/bees/execbee/execbee.go
@@ -18,6 +18,7 @@
  *    Authors:
  *      Dominik Schmidt <domme@tomahawk-player.org>
  *      Christian Muehlhaeuser <muesli@gmail.com>
+ *      Matthias Krauser <matthias@krauser.eu>
  */
 
 // Package execbee is a Bee that can launch external processes.
@@ -25,6 +26,7 @@ package execbee
 
 import (
 	"bufio"
+	"io"
 	"os/exec"
 	"strings"
 
@@ -45,12 +47,30 @@ func (mod *ExecBee) Action(action bees.Action) []bees.Placeholder {
 	switch action.Name {
 	case "execute":
 		var command string
+		var stdin string
+
 		action.Options.Bind("command", &command)
+		action.Options.Bind("stdin", &stdin)
 		mod.Logln("Executing locally: ", command)
 
 		go func() {
 			c := strings.Split(command, " ")
 			cmd := exec.Command(c[0], c[1:]...)
+
+			if stdin != "" {
+				stdinPipe, err := cmd.StdinPipe()
+
+				if err != nil {
+					mod.LogFatal("Error creating stdinPipe for Cmd", err)
+					return
+				}
+
+				go func() {
+					mod.Logf("StdIn" + stdin)
+					defer stdinPipe.Close()
+					io.WriteString(stdinPipe, stdin)
+				}()
+			}
 
 			// read and print stdout
 			outReader, err := cmd.StdoutPipe()

--- a/bees/execbee/execbeefactory.go
+++ b/bees/execbee/execbeefactory.go
@@ -104,7 +104,8 @@ func (factory *ExecBeeFactory) Actions() []bees.ActionDescriptor {
 					Description: "command to be executed",
 					Type:        "string",
 					Mandatory:   true,
-				}, {
+				},
+				{
 					Name:        "stdin",
 					Description: "stdin-Data for the command",
 					Type:        "string",

--- a/bees/execbee/execbeefactory.go
+++ b/bees/execbee/execbeefactory.go
@@ -18,6 +18,7 @@
  *    Authors:
  *      Dominik Schmidt <domme@tomahawk-player.org>
  *      Christian Muehlhaeuser <muesli@gmail.com>
+ *      Matthias Krauser <matthias@krauser.eu>
  */
 
 package execbee
@@ -103,6 +104,11 @@ func (factory *ExecBeeFactory) Actions() []bees.ActionDescriptor {
 					Description: "command to be executed",
 					Type:        "string",
 					Mandatory:   true,
+				}, {
+					Name:        "stdin",
+					Description: "stdin-Data for the command",
+					Type:        "string",
+					Mandatory:   false,
 				},
 			},
 		},


### PR DESCRIPTION
The commands executed by execbee can now receive data via stdin