### PR TITLE
Add tzdata to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN make embed
 FROM alpine
 
 RUN apk update && \
-    apk add --no-cache ca-certificates && \
+    apk add --no-cache ca-certificates tzdata && \
     update-ca-certificates
 
 COPY --from=builder /go/beehive/beehive /go/bin/beehive


### PR DESCRIPTION
When I developed something using alpine as base docker image, I wasn't able to set the correct time and timezone via the TZ environment variable until I added tzdata to the image.