### PR TITLE
Fix handling of boolean config values

### DIFF
--- a/bees/placeholders.go
+++ b/bees/placeholders.go
@@ -125,6 +125,8 @@ func ConvertValue(v interface{}, dst interface{}) error {
 			vt = strings.ToLower(vt)
 			if vt == "true" || vt == "on" || vt == "yes" || vt == "1" || vt == "t" {
 				*d = true
+			} else {
+				*d = false
 			}
 		case int64:
 			*d = vt > 0


### PR DESCRIPTION
Hey there,

I'm working on a bee right now (still WiP, but I will send a PR once it is finished) and discovered the following issue:
When a bee contains a boolean config value you cannot change the value from true to false without restarting beehive. It does work from false to true.

This PR fixes that. 
