### PR TITLE
Add JSON-Function for Templates

### DIFF
--- a/templatehelper/templatehelper.go
+++ b/templatehelper/templatehelper.go
@@ -22,6 +22,8 @@
 package templatehelper
 
 import (
+	"encoding/json"
+	htmlTemplate "html/template"
 	"regexp"
 	"strings"
 	"text/template"
@@ -30,6 +32,10 @@ import (
 // FuncMap contains all the common string helpers
 var (
 	FuncMap = template.FuncMap{
+		"Json": func(values ...interface{}) htmlTemplate.JS {
+			json, _ := json.Marshal(values)
+			return htmlTemplate.JS(json)
+		},
 		"Left": func(values ...interface{}) string {
 			return values[0].(string)[:values[1].(int)]
 		},

--- a/templatehelper/templatehelper.go
+++ b/templatehelper/templatehelper.go
@@ -32,7 +32,7 @@ import (
 // FuncMap contains all the common string helpers
 var (
 	FuncMap = template.FuncMap{
-		"Json": func(values ...interface{}) htmlTemplate.JS {
+		"JSON": func(values ...interface{}) htmlTemplate.JS {
 			json, _ := json.Marshal(values)
 			return htmlTemplate.JS(json)
 		},


### PR DESCRIPTION
This adds a json-Function to be used in String-Templates. In my Use-Case I serialize an entire Event and provide the Json-Document as Input to the ExecBee for further processing like this:

`{{.|Json}}`

I was not sure about the casing of "Json". I decided to go with that because it is easier to type and fits the existing functions. But technically it would be JSON. 