### PR TITLE
Add --debug flag

### DIFF
--- a/beehive.go
+++ b/beehive.go
@@ -45,6 +45,7 @@ import (
 var (
 	configFile  string
 	versionFlag bool
+	debugFlag   bool
 )
 
 // Config contains an entire configuration set for Beehive
@@ -95,6 +96,12 @@ func main() {
 			Value: false,
 			Desc:  "Beehive version",
 		},
+		{
+			V:     &debugFlag,
+			Name:  "debug",
+			Value: false,
+			Desc:  "Turn on debugging",
+		},
 	})
 
 	// Parse command-line args for all registered bees
@@ -107,7 +114,11 @@ func main() {
 
 	api.Run()
 
-	log.SetLevel(log.InfoLevel)
+	if debugFlag {
+		log.SetLevel(log.DebugLevel)
+	} else {
+		log.SetLevel(log.InfoLevel)
+	}
 
 	log.Println()
 	log.Println("Beehive is buzzing...")

--- a/bees/actions.go
+++ b/bees/actions.go
@@ -101,16 +101,16 @@ func execAction(action Action, opts map[string]interface{}) bool {
 	if (*bee).IsRunning() {
 		(*bee).LogAction()
 
-		log.Println("\tExecuting action:", a.Bee, "/", a.Name, "-", GetActionDescriptor(&a).Description)
+		log.Debugln("\tExecuting action:", a.Bee, "/", a.Name, "-", GetActionDescriptor(&a).Description)
 		for _, v := range a.Options {
-			log.Println("\t\tOptions:", v)
+			log.Debugln("\t\tOptions:", v)
 		}
 
 		(*bee).Action(a)
 	} else {
-		log.Println("\tNot executing action on stopped bee:", a.Bee, "/", a.Name, "-", GetActionDescriptor(&a).Description)
+		log.Debugln("\tNot executing action on stopped bee:", a.Bee, "/", a.Name, "-", GetActionDescriptor(&a).Description)
 		for _, v := range a.Options {
-			log.Println("\t\tOptions:", v)
+			log.Debugln("\t\tOptions:", v)
 		}
 	}
 

--- a/bees/chains.go
+++ b/bees/chains.go
@@ -97,12 +97,12 @@ func execChains(event *Event) {
 		ctx.FillMap(m)
 
 		failed := false
-		log.Println("Executing chain:", c.Name, "-", c.Description)
+		log.Debugln("Executing chain:", c.Name, "-", c.Description)
 		for _, el := range c.Filters {
 			if execFilter(el, m) {
-				log.Println("\t\tPassed filter!")
+				log.Debugln("\t\tPassed filter!")
 			} else {
-				log.Println("\t\tDid not pass filter!")
+				log.Debugln("\t\tDid not pass filter!")
 				failed = true
 				break
 			}

--- a/bees/events.go
+++ b/bees/events.go
@@ -21,9 +21,12 @@
 // Package bees is Beehive's central module system.
 package bees
 
-import log "github.com/sirupsen/logrus"
-import "runtime/debug"
-import "fmt"
+import (
+	"fmt"
+	"runtime/debug"
+
+	log "github.com/sirupsen/logrus"
+)
 
 // An Event describes an event including its parameters.
 type Event struct {
@@ -49,11 +52,11 @@ func handleEvents() {
 		bee := GetBee(event.Bee)
 		(*bee).LogEvent()
 
-		log.Println()
-		log.Println("Event received:", event.Bee, "/", event.Name, "-", GetEventDescriptor(&event).Description)
+		log.Debugln()
+		log.Debugln("Event received:", event.Bee, "/", event.Name, "-", GetEventDescriptor(&event).Description)
 		for _, v := range event.Options {
 			vv := truncateString(fmt.Sprintln(v), 1000)
-			log.Println("\tOptions:", vv)
+			log.Debugln("\tOptions:", vv)
 		}
 
 		go func() {


### PR DESCRIPTION
In addition to adding a new --debug flag to the binary, hide
some potentially sensitive information behind the debug flag,
such as the events content.