### PR TITLE
pushover: do not print token to stdout

### DIFF
--- a/bees/pushoverbee/pushoverbee.go
+++ b/bees/pushoverbee/pushoverbee.go
@@ -71,14 +71,14 @@ func (mod *PushoverBee) Action(action bees.Action) []bees.Placeholder {
 			msg.Set("title", title)
 		}
 
-		mod.Logln(msg)
+		mod.LogDebugf("Message: %s", msg)
 		resp, err := http.PostForm("https://api.pushover.net/1/messages.json", msg)
 		if err != nil {
 			panic(err)
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode == 200 {
-			mod.Logln("Pushover send message success.")
+			mod.LogDebugf("Pushover send message success.", nil)
 		}
 
 	default:

--- a/bees/pushoverbee/pushoverbee.go
+++ b/bees/pushoverbee/pushoverbee.go
@@ -78,7 +78,7 @@ func (mod *PushoverBee) Action(action bees.Action) []bees.Placeholder {
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode == 200 {
-			mod.LogDebugf("Pushover send message success.", nil)
+			mod.LogDebugf("Pushover send message success.")
 		}
 
 	default:


### PR DESCRIPTION
`mod.Logln(msg)` will write the Pushover tokens to stdout, which isn't ideal
if the logs are saved somewhere (when running from systemd for example).

Send the debug output to the debug log instead.