### PR TITLE
rssbee: set default value skip_first improves UX

### DIFF
--- a/bees/rssbee/rssbeefactory.go
+++ b/bees/rssbee/rssbeefactory.go
@@ -78,6 +78,7 @@ func (factory *RSSBeeFactory) Options() []bees.BeeOptionDescriptor {
 			Description: "Whether to skip already existing entries",
 			Type:        "bool",
 			Mandatory:   false,
+			Default:     false,
 		},
 	}
 	return opts


### PR DESCRIPTION
Setting default makes it easier to understand what kind of value
"Whether to skip already existing entries" expects: 1/0? yes/no? true/false?

Without the patch:

![Screenshot 2019-10-19 at 12 20 11](https://user-images.githubusercontent.com/10998/67143503-59e3c580-f26c-11e9-88d0-dc8e4d399e9a.png)

With the patch:

![Screenshot 2019-10-19 at 12 20 42](https://user-images.githubusercontent.com/10998/67143509-61a36a00-f26c-11e9-918d-e2b7e4124a12.png)
