### PR TITLE
Updated MastodonBee

### DIFF
--- a/bees/mastodonbee/events.go
+++ b/bees/mastodonbee/events.go
@@ -1,0 +1,244 @@
+/*
+ *    Copyright (C) 2020 Christian Muehlhaeuser
+ *                  2020 Nicolas Martin
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Affero General Public License as published
+ *    by the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    Authors:
+ *      Christian Muehlhaeuser <muesli@gmail.com>
+ *      Nicolas Martin <penguwin@penguwin.eu>
+ */
+package mastodonbee
+
+import (
+	"context"
+
+	mastodon "github.com/mattn/go-mastodon"
+	"github.com/muesli/beehive/bees"
+)
+
+// handleUpdateEvent handles incoming Toot updates from mastodon from yourself
+// and from people you follow.
+func (mod *mastodonBee) handleStatus(status *mastodon.Status) {
+	ev := bees.Event{
+		Bee:  mod.Name(),
+		Name: "toot_fetched",
+		Options: []bees.Placeholder{
+			{
+				Name:  "id",
+				Value: string(status.ID),
+				Type:  "string",
+			},
+			{
+				Name:  "text",
+				Value: status.Content,
+				Type:  "string",
+			},
+			{
+				Name:  "user_id",
+				Value: string(status.Account.ID),
+				Type:  "string",
+			},
+			{
+				Name:  "username",
+				Value: status.Account.DisplayName,
+				Type:  "string",
+			},
+			{
+				Name:  "reblogs",
+				Value: status.ReblogsCount,
+				Type:  "int64",
+			},
+			{
+				Name:  "favourites",
+				Value: status.FavouritesCount,
+				Type:  "int64",
+			},
+			{
+				Name:  "url",
+				Value: status.URL,
+				Type:  "string",
+			},
+		},
+	}
+	mod.evchan <- ev
+}
+
+func (mod *mastodonBee) handleNotification(notif *mastodon.Notification) {
+	switch notif.Type {
+
+	case "follow":
+		rel, err := mod.client.GetAccountRelationships(context.Background(), []string{string(notif.Account.ID)})
+		if err != nil {
+			mod.LogErrorf("Failed to fetch account relationship at follow event: %v", err)
+			return
+		}
+
+		if len(rel) == 0 {
+			// NOTE: Does this even happen?
+			// TODO: Investigate
+			mod.LogErrorf("No relationship information was fetched")
+			return
+		}
+
+		// NOTE: there should be only one relationship entity fetched
+		ev := bees.Event{
+			Bee:  mod.Name(),
+			Name: "follow",
+			Options: []bees.Placeholder{
+				{
+					Name:  "user_id",
+					Value: string(notif.Account.ID),
+					Type:  "string",
+				},
+				{
+					Name:  "username",
+					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "following",
+					Value: rel[0].Following,
+					Type:  "bool",
+				},
+				{
+					Name:  "followed_by",
+					Value: rel[0].FollowedBy,
+					Type:  "bool",
+				},
+				{
+					Name:  "followers",
+					Value: notif.Account.FollowersCount,
+					Type:  "int64",
+				},
+				{
+					Name:  "follows",
+					Value: notif.Account.FollowingCount,
+					Type:  "int64",
+				},
+			},
+		}
+		mod.evchan <- ev
+
+	case "favourite":
+		ev := bees.Event{
+			Bee:  mod.Name(),
+			Name: "favourite",
+			Options: []bees.Placeholder{
+				{
+					Name:  "id",
+					Value: string(notif.Status.ID),
+					Type:  "string",
+				},
+				{
+					Name:  "user_id",
+					Value: string(notif.Account.ID),
+					Type:  "string",
+				},
+				{
+					Name:  "username",
+					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "text",
+					Value: notif.Status.Content,
+					Type:  "string",
+				},
+				{
+					Name:  "url",
+					Value: notif.Status.URL,
+					Type:  "string",
+				},
+				{
+					Name:  "favourites",
+					Value: notif.Status.FavouritesCount,
+					Type:  "int64",
+				},
+			},
+		}
+		mod.evchan <- ev
+
+	case "reblog":
+		ev := bees.Event{
+			Bee:  mod.Name(),
+			Name: "reblog",
+			Options: []bees.Placeholder{
+				{
+					Name:  "user_id",
+					Value: string(notif.Account.ID),
+					Type:  "string",
+				},
+				{
+					Name:  "username",
+					Value: notif.Status.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "text",
+					Value: notif.Status.Content,
+					Type:  "string",
+				},
+				{
+					Name:  "url",
+					Value: notif.Status.URL,
+					Type:  "string",
+				},
+				{
+					Name:  "reblogs",
+					Value: notif.Status.ReblogsCount,
+					Type:  "int64",
+				},
+			},
+		}
+		mod.evchan <- ev
+
+	case "mention":
+		ev := bees.Event{
+			Bee:  mod.Name(),
+			Name: "mention",
+			Options: []bees.Placeholder{
+				{
+					Name:  "id",
+					Value: string(notif.Status.ID),
+					Type:  "string",
+				},
+				{
+					Name:  "user_id",
+					Value: string(notif.Account.ID),
+					Type:  "string",
+				},
+				{
+					Name:  "username",
+					Value: notif.Status.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "text",
+					Value: notif.Status.Content,
+					Type:  "string",
+				},
+				{
+					Name:  "url",
+					Value: notif.Status.URL,
+					Type:  "string",
+				},
+			},
+		}
+		mod.evchan <- ev
+
+	default:
+		mod.LogErrorf("Unkown notification type: %s", notif.Type)
+	}
+}

--- a/bees/mastodonbee/mastodonbee.go
+++ b/bees/mastodonbee/mastodonbee.go
@@ -56,13 +56,211 @@ func (mod *mastodonBee) Action(action bees.Action) []bees.Placeholder {
 		action.Options.Bind("text", &text)
 		mod.Logf("Attempting to post \"%s\" to Mastodon", text)
 
-		// Post status toot on mastodon
+		// Post status toot on mastodon, event gets triggered automatically via
+		// the toot_fetched even.
 		_, err := mod.client.PostStatus(context.Background(), &mastodon.Toot{
 			Status: text,
 		})
 		if err != nil {
 			mod.LogErrorf("Error sending toot: %v", err)
 		}
+
+	case "delete_toot":
+		var id string
+		action.Options.Bind("id", &id)
+		mod.Logf("Attempting to delete toot \"%s\"", id)
+
+		// Event is automatically handled in handleStreamEvent()
+		err := mod.client.DeleteStatus(context.Background(), mastodon.ID(id))
+		if err != nil {
+			mod.LogErrorf("Error deleting toot: %v", err)
+		}
+
+	case "get_toots": // returns the current user's toots
+		mod.Logf("Attempting to get current user")
+		acc, err := mod.client.GetAccountCurrentUser(context.Background())
+		if err != nil {
+			mod.LogErrorf("Error getting current user: %v", err)
+			return outs
+		}
+
+		mod.Logf("Attempting to get current user's toots")
+		statuses, err := mod.client.GetAccountStatuses(context.Background(), acc.ID, &mastodon.Pagination{})
+		if err != nil {
+			mod.LogErrorf("Error getting current user's toots: %v", err)
+			return outs
+		}
+
+		// create a toot_fetched event for every status
+		for _, status := range statuses {
+			mod.handleStatus(status)
+		}
+
+	case "follow":
+		var id string
+		action.Options.Bind("id", &id)
+		mod.Logf("Attempting to follow account: %s", id)
+
+		rel, err := mod.client.AccountFollow(context.Background(), mastodon.ID(id))
+		if err != nil {
+			mod.LogErrorf("Failed to follow account %s: %v", id, err)
+			return outs
+		}
+
+		ev := bees.Event{
+			Bee:  mod.Name(),
+			Name: "followed",
+			Options: []bees.Placeholder{
+				{
+					Name:  "user_id",
+					Value: id,
+					Type:  "string",
+				},
+				{
+					Name:  "following",
+					Value: rel.Following,
+					Type:  "bool",
+				},
+				{
+					Name:  "requested",
+					Value: rel.Requested,
+					Type:  "bool",
+				},
+				{
+					Name:  "followed_by",
+					Value: rel.FollowedBy,
+					Type:  "bool",
+				},
+			},
+		}
+		mod.evchan <- ev
+
+	case "unfollow":
+		var id string
+		action.Options.Bind("id", &id)
+		mod.Logf("Attempting to unfollow account: %s", id)
+
+		rel, err := mod.client.AccountUnfollow(context.Background(), mastodon.ID(id))
+		if err != nil {
+			mod.LogErrorf("Failed to unfollow account %s: %v", id, err)
+			return outs
+		}
+
+		ev := bees.Event{
+			Bee:  mod.Name(),
+			Name: "unfollowed",
+			Options: []bees.Placeholder{
+				{
+					Name:  "user_id",
+					Value: id,
+					Type:  "string",
+				},
+				{
+					Name:  "following",
+					Value: rel.Following,
+					Type:  "bool",
+				},
+				{
+					Name:  "followed_by",
+					Value: rel.FollowedBy,
+					Type:  "bool",
+				},
+			},
+		}
+		mod.evchan <- ev
+
+	case "favourite":
+		var id string
+		action.Options.Bind("id", &id)
+		mod.Logf("Attempting to favourite toot: %s", id)
+
+		status, err := mod.client.Favourite(context.Background(), mastodon.ID(id))
+		if err != nil {
+			mod.LogErrorf("Failed to favourite toot: %v", err)
+		}
+
+		ev := bees.Event{
+			Bee:  mod.Name(),
+			Name: "favourited",
+			Options: []bees.Placeholder{
+				{
+					Name:  "id",
+					Value: id,
+					Type:  "string",
+				},
+				{
+					Name:  "user_id",
+					Value: string(status.Account.ID),
+					Type:  "string",
+				},
+				{
+					Name:  "username",
+					Value: status.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "text",
+					Value: status.Content,
+					Type:  "string",
+				},
+				{
+					Name:  "url",
+					Value: status.URL,
+					Type:  "string",
+				},
+				{
+					Name:  "favourites",
+					Value: status.FavouritesCount,
+					Type:  "int64",
+				},
+			},
+		}
+		mod.evchan <- ev
+
+	case "reblog":
+		var id string
+		action.Options.Bind("id", &id)
+		mod.Logf("Attempting to reblog toot %s", id)
+
+		// reblog-Event should automatically be handled in handleStreamEvent()
+		status, err := mod.client.Reblog(context.Background(), mastodon.ID(id))
+		if err != nil {
+			mod.LogErrorf("Failed to reblog toot: %v", err)
+			return outs
+		}
+
+		ev := bees.Event{
+			Bee:  mod.Name(),
+			Name: "reblogged",
+			Options: []bees.Placeholder{
+				{
+					Name:  "user_id",
+					Value: string(status.Account.ID),
+					Type:  "string",
+				},
+				{
+					Name:  "username",
+					Value: status.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "text",
+					Value: status.Content,
+					Type:  "string",
+				},
+				{
+					Name:  "url",
+					Value: status.URL,
+					Type:  "string",
+				},
+				{
+					Name:  "reblogs",
+					Value: status.ReblogsCount,
+					Type:  "int64",
+				},
+			},
+		}
+		mod.evchan <- ev
 
 	default:
 		mod.LogErrorf("Unkown action: %s", action.Name)

--- a/bees/mastodonbee/mastodonbeefactory.go
+++ b/bees/mastodonbee/mastodonbeefactory.go
@@ -16,7 +16,7 @@
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  *    Authors:
- *      Nicolas Martin <penguwin@systemli.org>
+ *      Nicolas Martin <penguwin@penguwin.eu>
  *      Christian Muehlhaeuser <muesli@gmail.com>
  */
 
@@ -106,12 +106,192 @@ func (factory *mastodonBeeFactory) Events() []bees.EventDescriptor {
 	events := []bees.EventDescriptor{
 		{
 			Namespace:   factory.Name(),
-			Name:        "toot_sent",
-			Description: "A toot has been sent",
+			Name:        "deleted",
+			Description: "is triggered when a toot has been deleted",
 			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of the deleted toot",
+					Type:        "string",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "toot_fetched",
+			Description: "is triggered when a toot has been fetched",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of the toot",
+					Type:        "string",
+				},
 				{
 					Name:        "text",
 					Description: "Text of the toot that has been sent",
+					Type:        "string",
+				},
+				{
+					Name:        "user_id",
+					Description: "Mastodon ID if the toots author",
+					Type:        "string",
+				},
+				{
+					Name:        "username",
+					Description: "Mastodon handle of the toots author",
+					Type:        "string",
+				},
+				{
+					Name:        "reblogs",
+					Description: "reblogs count",
+					Type:        "int64",
+				},
+				{
+					Name:        "favourites",
+					Description: "favourites count",
+					Type:        "int64",
+				},
+				{
+					Name:        "url",
+					Description: "The url for the toot",
+					Type:        "string",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "follow",
+			Description: "is triggered when someone wants to follow you",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "user_id",
+					Description: "Mastodon ID of the user which triggered the follow event",
+					Type:        "string",
+				},
+				{
+					Name:        "username",
+					Description: "Mastodon handle of the user which triggered the follow event",
+					Type:        "string",
+				},
+				{
+					Name:        "following",
+					Description: "Indicates if your're following the user",
+					Type:        "bool",
+				},
+				{
+					Name:        "followed_by",
+					Description: "Indicates if you're followed by the user",
+					Type:        "bool",
+				},
+				{
+					Name:        "followers",
+					Description: "Number of followers for the user which triggered the follow request",
+					Type:        "int64",
+				},
+				{
+					Name:        "follows",
+					Description: "Number of follows for the user which triggered the follow request",
+					Type:        "int64",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "favourite",
+			Description: "is triggered when someone favourites one of your toots.",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of toot",
+					Type:        "string",
+				},
+				{
+					Name:        "user_id",
+					Description: "Mastodon ID of the user that favourited your toot",
+					Type:        "string",
+				},
+				{
+					Name:        "username",
+					Description: "The Mastodon handle of the user that favourited your toot",
+					Type:        "string",
+				},
+				{
+					Name:        "text",
+					Description: "text content of the favourited toot",
+					Type:        "string",
+				},
+				{
+					Name:        "url",
+					Description: "URL of the favourited toot",
+					Type:        "string",
+				},
+				{
+					Name:        "favourites",
+					Description: "The count of favourites for this toot",
+					Type:        "int64",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "reblog",
+			Description: "is triggered when someone reblogs on of your toots",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "user_id",
+					Description: "Mastodon ID of the user tht reblogged your toot",
+					Type:        "string",
+				},
+				{
+					Name:        "username",
+					Description: "Mastodon handle of the user that reblogged your toot",
+					Type:        "string",
+				},
+				{
+					Name:        "text",
+					Description: "text content of the mention",
+					Type:        "string",
+				},
+				{
+					Name:        "url",
+					Description: "URL of the mention",
+					Type:        "string",
+				},
+				{
+					Name:        "reblogs",
+					Description: "Number of reblogs for the post",
+					Type:        "string",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "mention",
+			Description: "is triggered whenever someone mentions you on Mastodon",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of toot",
+					Type:        "string",
+				},
+				{
+					Name:        "user_id",
+					Description: "Mastodon ID if the mention's author",
+					Type:        "string",
+				},
+				{
+					Name:        "username",
+					Description: "The Mastodon handle of the mention's author",
+					Type:        "string",
+				},
+				{
+					Name:        "text",
+					Description: "text content of the mention",
+					Type:        "string",
+				},
+				{
+					Name:        "url",
+					Description: "URL of the mention",
 					Type:        "string",
 				},
 			},

--- a/bees/mastodonbee/mastodonbeefactory.go
+++ b/bees/mastodonbee/mastodonbeefactory.go
@@ -197,8 +197,57 @@ func (factory *mastodonBeeFactory) Events() []bees.EventDescriptor {
 		},
 		{
 			Namespace:   factory.Name(),
+			Name:        "followed",
+			Description: "is triggered when you followed someone on Mastodon",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "user_id",
+					Description: "Mastodon ID of the user to follow",
+					Type:        "string",
+				},
+				{
+					Name:        "following",
+					Description: "Indicates if your're following the user",
+					Type:        "bool",
+				},
+				{
+					Name:        "requested",
+					Description: "Indicates if you've requested following the user",
+					Type:        "bool",
+				},
+				{
+					Name:        "followed_by",
+					Description: "Indicates if you're followed by the user",
+					Type:        "bool",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "unfollowed",
+			Description: "is triggered when you unfollow someone on Mastodon",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "user_id",
+					Description: "Mastodon ID of the user to follow",
+					Type:        "string",
+				},
+				{
+					Name:        "following",
+					Description: "Indicates if your're following the user",
+					Type:        "bool",
+				},
+				{
+					Name:        "followed_by",
+					Description: "Indicates if you're followed by the user",
+					Type:        "bool",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
 			Name:        "favourite",
-			Description: "is triggered when someone favourites one of your toots.",
+			Description: "is triggered when someone favourites one of your toots",
 			Options: []bees.PlaceholderDescriptor{
 				{
 					Name:        "id",
@@ -213,6 +262,43 @@ func (factory *mastodonBeeFactory) Events() []bees.EventDescriptor {
 				{
 					Name:        "username",
 					Description: "The Mastodon handle of the user that favourited your toot",
+					Type:        "string",
+				},
+				{
+					Name:        "text",
+					Description: "text content of the favourited toot",
+					Type:        "string",
+				},
+				{
+					Name:        "url",
+					Description: "URL of the favourited toot",
+					Type:        "string",
+				},
+				{
+					Name:        "favourites",
+					Description: "The count of favourites for this toot",
+					Type:        "int64",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "favourited",
+			Description: "is triggered when you favourite someones toot",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of toot",
+					Type:        "string",
+				},
+				{
+					Name:        "user_id",
+					Description: "Mastodon ID of the toots author",
+					Type:        "string",
+				},
+				{
+					Name:        "username",
+					Description: "The Mastodon handle of the toots author",
 					Type:        "string",
 				},
 				{
@@ -249,12 +335,44 @@ func (factory *mastodonBeeFactory) Events() []bees.EventDescriptor {
 				},
 				{
 					Name:        "text",
-					Description: "text content of the mention",
+					Description: "text content of the reblog",
 					Type:        "string",
 				},
 				{
 					Name:        "url",
-					Description: "URL of the mention",
+					Description: "URL of the reblog",
+					Type:        "string",
+				},
+				{
+					Name:        "reblogs",
+					Description: "Number of reblogs for the post",
+					Type:        "string",
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "reblogged",
+			Description: "is triggered when you reblog a toot",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "user_id",
+					Description: "Mastodon ID of the reblogged toots author",
+					Type:        "string",
+				},
+				{
+					Name:        "username",
+					Description: "Mastodon handle of the reblogged toots author",
+					Type:        "string",
+				},
+				{
+					Name:        "text",
+					Description: "text content of the reblog",
+					Type:        "string",
+				},
+				{
+					Name:        "url",
+					Description: "URL of the reblog",
 					Type:        "string",
 				},
 				{
@@ -311,6 +429,77 @@ func (factory *mastodonBeeFactory) Actions() []bees.ActionDescriptor {
 				{
 					Name:        "text",
 					Description: "Text of the status to toot, may not be longer than 500 characters",
+					Type:        "string",
+					Mandatory:   true,
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "delete_toot",
+			Description: "Delete a toot from mastodon",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of the to toot to delete",
+					Type:        "string",
+					Mandatory:   true,
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "get_toots",
+			Description: "Returns the current user's toots",
+			Options:     []bees.PlaceholderDescriptor{},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "follow",
+			Description: "Follow an user on Mastodon",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of the to user to follow",
+					Type:        "string",
+					Mandatory:   true,
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "unfollow",
+			Description: "unfollow an user on Mastodon",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of the to user to unfollow",
+					Type:        "string",
+					Mandatory:   true,
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "reblog",
+			Description: "reblog a toot on Mastodon",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of the to toot to reblog",
+					Type:        "string",
+					Mandatory:   true,
+				},
+			},
+		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "favourite",
+			Description: "favourite a toot on Mastodon",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "id",
+					Description: "The ID of the to toot to favourite",
 					Type:        "string",
 					Mandatory:   true,
 				},


### PR DESCRIPTION
Modified the MastodonBee to make use of the **events** provided within the UserStream:

- `toot_fetched`: is triggered whenever a Toot was fetched. (includes your own Toots and Toots from people you follow)
- `deleted`: is triggerd when a Toot has been deleted from Mastodon. (Includes deletion of Toots from people you follow and your own)
- `follow`: is triggered when a user wants to follow you on mastodon.
- `favourite`: is triggered when a user favourites one of your toot.
- `reblog`: is triggered when a user reblogs one of your toots.
- `mention`: is triggered when a user mentions you on mastodon.

Also Implemented some more **actions**:
- `delete_toot`: Deletes a toot -> triggers `deleted` event
- `get_toots`: Fetches the current users timeline -> triggers `toot_fetched` event
- `follow`: Follows users -> triggers `followed` event
- `unfollow`: Unfollows users -> triggers `unfollowed` event
- `reblog`: Reblogs toots on mastodon -> triggers `reblogged` event
- `favourite`: Favourites toots on mastodon -> triggers `favourited` event

As you can read above these new actions also provide another new set of **events**:
- `followed`: Triggers when _you_  follow someone on mastodon via beehive
- `unfollowed`: Triggers when _you_  unfollow someone on mastodon via beehive
- `reblogged`: Triggers when _you_ reblog a toot on mastodon via beehive
- `favourite`: Triggers when _you_ favourite a toot on mastodon via beehive