### PR TITLE
Refactored Mastodonbee a bit

### DIFF
--- a/bees/mastodonbee/events.go
+++ b/bees/mastodonbee/events.go
@@ -70,6 +70,11 @@ func (mod *MastodonBee) handleStatus(status *mastodon.Status) {
 				Value: status.URL,
 				Type:  "string",
 			},
+			{
+				Name:  "created",
+				Value: status.CreatedAt,
+				Type:  "time.Time",
+			},
 		},
 	}
 	mod.evchan <- ev

--- a/bees/mastodonbee/events.go
+++ b/bees/mastodonbee/events.go
@@ -30,7 +30,7 @@ import (
 
 // handleUpdateEvent handles incoming Toot updates from mastodon from yourself
 // and from people you follow.
-func (mod *mastodonBee) handleStatus(status *mastodon.Status) {
+func (mod *MastodonBee) handleStatus(status *mastodon.Status) {
 	ev := bees.Event{
 		Bee:  mod.Name(),
 		Name: "toot_fetched",
@@ -75,7 +75,7 @@ func (mod *mastodonBee) handleStatus(status *mastodon.Status) {
 	mod.evchan <- ev
 }
 
-func (mod *mastodonBee) handleNotification(notif *mastodon.Notification) {
+func (mod *MastodonBee) handleNotification(notif *mastodon.Notification) {
 	switch notif.Type {
 
 	case "follow":

--- a/bees/mastodonbee/mastodonbee.go
+++ b/bees/mastodonbee/mastodonbee.go
@@ -31,8 +31,8 @@ import (
 	"github.com/muesli/beehive/bees"
 )
 
-// mastodonBee is a Bee that can connect to mastodon.
-type mastodonBee struct {
+// MastodonBee is a Bee that can connect to mastodon.
+type MastodonBee struct {
 	bees.Bee
 
 	server       string
@@ -47,7 +47,7 @@ type mastodonBee struct {
 }
 
 // Action triggers the action passed to it.
-func (mod *mastodonBee) Action(action bees.Action) []bees.Placeholder {
+func (mod *MastodonBee) Action(action bees.Action) []bees.Placeholder {
 	outs := []bees.Placeholder{}
 
 	switch action.Name {
@@ -268,7 +268,7 @@ func (mod *mastodonBee) Action(action bees.Action) []bees.Placeholder {
 	return outs
 }
 
-func (mod *mastodonBee) handleStreamEvent(item interface{}) {
+func (mod *MastodonBee) handleStreamEvent(item interface{}) {
 	switch e := item.(type) {
 	case *mastodon.UpdateEvent:
 		mod.handleStatus(e.Status)
@@ -292,7 +292,7 @@ func (mod *mastodonBee) handleStreamEvent(item interface{}) {
 	}
 }
 
-func (mod *mastodonBee) handleStream() {
+func (mod *MastodonBee) handleStream() {
 	timeline, err := mod.client.StreamingUser(context.Background())
 	if err != nil {
 		mod.LogErrorf("Failed to get user stream: %+v", err)
@@ -310,7 +310,7 @@ func (mod *mastodonBee) handleStream() {
 }
 
 // Run executes the Bee's event loop.
-func (mod *mastodonBee) Run(eventChan chan bees.Event) {
+func (mod *MastodonBee) Run(eventChan chan bees.Event) {
 	// Create the new api client
 	c := mastodon.NewClient(&mastodon.Config{
 		Server:       mod.server,
@@ -339,7 +339,7 @@ func (mod *mastodonBee) Run(eventChan chan bees.Event) {
 }
 
 // ReloadOptions parses the config options and initializes the Bee.
-func (mod *mastodonBee) ReloadOptions(options bees.BeeOptions) {
+func (mod *MastodonBee) ReloadOptions(options bees.BeeOptions) {
 	mod.SetOptions(options)
 
 	options.Bind("server", &mod.server)

--- a/bees/mastodonbee/mastodonbeefactory.go
+++ b/bees/mastodonbee/mastodonbeefactory.go
@@ -156,6 +156,11 @@ func (factory *MastodonBeeFactory) Events() []bees.EventDescriptor {
 					Description: "The url for the toot",
 					Type:        "string",
 				},
+				{
+					Name:        "created",
+					Description: "The timestamp of the toots creation",
+					Type:        "time.Time",
+				},
 			},
 		},
 		{

--- a/bees/mastodonbee/mastodonbeefactory.go
+++ b/bees/mastodonbee/mastodonbeefactory.go
@@ -24,14 +24,14 @@ package mastodonbee
 
 import "github.com/muesli/beehive/bees"
 
-// mastodonBeeFactory is a factory for mastodonBees.
-type mastodonBeeFactory struct {
+// MastodonBeeFactory is a factory for mastodonBees.
+type MastodonBeeFactory struct {
 	bees.BeeFactory
 }
 
 // New returns a new Bee instance configured with the supplied options.
-func (factory *mastodonBeeFactory) New(name, description string, options bees.BeeOptions) bees.BeeInterface {
-	bee := mastodonBee{
+func (factory *MastodonBeeFactory) New(name, description string, options bees.BeeOptions) bees.BeeInterface {
+	bee := MastodonBee{
 		Bee: bees.NewBee(name, factory.ID(), description, options),
 	}
 	bee.ReloadOptions(options)
@@ -40,32 +40,32 @@ func (factory *mastodonBeeFactory) New(name, description string, options bees.Be
 }
 
 // ID returns the ID of this Bee.
-func (factory *mastodonBeeFactory) ID() string {
+func (factory *MastodonBeeFactory) ID() string {
 	return "mastodonbee"
 }
 
 // Name returns the name of this Bee.
-func (factory *mastodonBeeFactory) Name() string {
+func (factory *MastodonBeeFactory) Name() string {
 	return "mastodon"
 }
 
 // Description returns the description of this Bee.
-func (factory *mastodonBeeFactory) Description() string {
+func (factory *MastodonBeeFactory) Description() string {
 	return "Interact with mastodon"
 }
 
 // Image returns the filename of an image for this Bee.
-func (factory *mastodonBeeFactory) Image() string {
+func (factory *MastodonBeeFactory) Image() string {
 	return factory.ID() + ".png"
 }
 
 // LogoColor returns the preferred logo background color (used by the admin interface).
-func (factory *mastodonBeeFactory) LogoColor() string {
+func (factory *MastodonBeeFactory) LogoColor() string {
 	return "#003b66"
 }
 
 // Options returns the options available to configure this Bee.
-func (factory *mastodonBeeFactory) Options() []bees.BeeOptionDescriptor {
+func (factory *MastodonBeeFactory) Options() []bees.BeeOptionDescriptor {
 	opts := []bees.BeeOptionDescriptor{
 		{
 			Name:        "server",
@@ -102,7 +102,7 @@ func (factory *mastodonBeeFactory) Options() []bees.BeeOptionDescriptor {
 }
 
 // Events describes the available events provided by this Bee.
-func (factory *mastodonBeeFactory) Events() []bees.EventDescriptor {
+func (factory *MastodonBeeFactory) Events() []bees.EventDescriptor {
 	events := []bees.EventDescriptor{
 		{
 			Namespace:   factory.Name(),
@@ -419,7 +419,7 @@ func (factory *mastodonBeeFactory) Events() []bees.EventDescriptor {
 }
 
 // Actions describes the available actions provided by this Bee.
-func (factory *mastodonBeeFactory) Actions() []bees.ActionDescriptor {
+func (factory *MastodonBeeFactory) Actions() []bees.ActionDescriptor {
 	actions := []bees.ActionDescriptor{
 		{
 			Namespace:   factory.Name(),
@@ -510,6 +510,6 @@ func (factory *mastodonBeeFactory) Actions() []bees.ActionDescriptor {
 }
 
 func init() {
-	f := mastodonBeeFactory{}
+	f := MastodonBeeFactory{}
 	bees.RegisterFactory(&f)
 }


### PR DESCRIPTION
I refactored the MastodonBee a bit. 
-  renamed `mastodonBee/Factory` to `MastodonBee/Factory` as starting with an uppercase letter is more consistent with the naming scheme of other hives/bees.
- Add timestamps in the `toot_fetched`-Event. This resolves #247 as we can already delete toots by ID.

I also created a [gist](https://gist.github.com/penguwin/67a5ee185458eca9772fc85649b34e04) with a skeleton for Mastodon&IRC interaction. You'd just need to fill in the credentials and the desired IRC channel.