### PR TITLE
Load and write config from/to standard paths

### DIFF
--- a/beehive.go
+++ b/beehive.go
@@ -91,7 +91,7 @@ func main() {
 	var config cfg.Config
 	var err error
 	if configFile != cfg.DefaultPath() {
-		_, err = cfg.LoadConfig(configFile)
+		config, err = cfg.LoadConfig(configFile)
 		if err != nil {
 			log.Fatalf("Error loading specified config file %s. err: %v", configFile, err)
 		}

--- a/beehive.go
+++ b/beehive.go
@@ -50,9 +50,10 @@ var (
 func main() {
 	app.AddFlags([]app.CliFlag{
 		{
-			V:    &configFile,
-			Name: "config",
-			Desc: "Config-file to use",
+			V:     &configFile,
+			Name:  "config",
+			Value: cfg.DefaultPath(),
+			Desc:  "Config-file to use",
 		},
 		{
 			V:     &versionFlag,
@@ -87,25 +88,18 @@ func main() {
 	log.Println()
 	log.Println("Beehive is buzzing...")
 
-	config := cfg.Config{}
+	var config cfg.Config
 	var err error
-	if configFile == "" {
-		configFile = cfg.FindUserConfigPath()
-		if configFile != "" {
-			config, err = cfg.LoadConfig(configFile)
+	if configFile != cfg.DefaultPath() {
+		_, err = cfg.LoadConfig(configFile)
+		if err != nil {
+			log.Fatalf("Error loading specified config file %s. err: %v", configFile, err)
 		}
 	} else {
-		config, err = cfg.LoadConfig(configFile)
-	}
-
-	if err != nil {
-		log.Panicf("Error loading config file %s!: %v", configFile, err)
-	}
-	if configFile != "" {
-		log.Printf("Config file loaded from %s\n", configFile)
-	} else {
-		configFile = cfg.DefaultPath()
-		log.Println("No config file found, loading defaults")
+		configFile, config, err = cfg.Load()
+		if err != nil {
+			log.Fatalf("Error loading user config file %s. err: %v", configFile, err)
+		}
 	}
 
 	// Load actions from config

--- a/beehive.go
+++ b/beehive.go
@@ -90,15 +90,23 @@ func main() {
 
 	var config cfg.Config
 	var err error
-	if configFile != cfg.DefaultPath() {
-		config, err = cfg.LoadConfig(configFile)
+	if configFile != cfg.DefaultPath() { // the user specified a custom config path
+		config, err = cfg.Load(configFile)
 		if err != nil {
 			log.Fatalf("Error loading specified config file %s. err: %v", configFile, err)
 		}
-	} else {
-		configFile, config, err = cfg.Load()
-		if err != nil {
-			log.Fatalf("Error loading user config file %s. err: %v", configFile, err)
+	} else { // try to load config from user paths
+		path := cfg.Lookup()
+		if path == "" {
+			log.Info("No config file found, loading defaults")
+			config = cfg.Config{}
+		} else {
+			configFile = path
+			log.Infof("Loading config file from %s", path)
+			config, err = cfg.Load(path)
+			if err != nil {
+				log.Fatalf("Error loading user config file %s. err: %v", configFile, err)
+			}
 		}
 	}
 
@@ -119,7 +127,7 @@ func main() {
 		abort := false
 		switch s {
 		case syscall.SIGHUP:
-			config, err := cfg.LoadConfig(configFile)
+			config, err := cfg.Load(configFile)
 			if err != nil {
 				log.Panicf("Error loading config from %s: %v", configFile, err)
 			}
@@ -147,7 +155,7 @@ func main() {
 	config.Bees = bees.BeeConfigs()
 	config.Chains = bees.GetChains()
 	config.Actions = bees.GetActions()
-	err = cfg.SaveConfig(configFile, config)
+	err = cfg.Save(configFile, config)
 	if err != nil {
 		log.Printf("Error saving config file to %s! %v", configFile, err)
 	}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -53,7 +53,7 @@ func DefaultPath() string {
 func Lookup() string {
 	paths := []string{}
 	defaultPath := DefaultPath()
-	if Exist(defaultPath) {
+	if exist(defaultPath) {
 		paths = append(paths, defaultPath)
 	}
 
@@ -65,7 +65,7 @@ func Lookup() string {
 		cwd = "."
 	}
 	cwdCfg := filepath.Join(cwd, cfgFileName)
-	if Exist(cwdCfg) {
+	if exist(cwdCfg) {
 		paths = append([]string{cwdCfg}, paths...)
 	}
 	if len(paths) == 0 {
@@ -74,7 +74,7 @@ func Lookup() string {
 	return paths[0]
 }
 
-// Loads chains from config
+// Load loads chains from config
 func Load(file string) (Config, error) {
 	config := Config{}
 
@@ -91,10 +91,10 @@ func Load(file string) (Config, error) {
 	return config, nil
 }
 
-// Saves chains to config
+// Save saves chains to config
 func Save(file string, c Config) error {
 	cfgDir := filepath.Dir(file)
-	if !Exist(cfgDir) {
+	if !exist(cfgDir) {
 		os.MkdirAll(cfgDir, 0755)
 	}
 
@@ -106,7 +106,8 @@ func Save(file string, c Config) error {
 	return err
 }
 
-func SaveCurrentConfig(file string) error {
+// SaveCurrent saves current in-memory configuration to the config file
+func SaveCurrent(file string) error {
 	config := Config{}
 	config.Bees = bees.BeeConfigs()
 	config.Chains = bees.GetChains()
@@ -114,7 +115,7 @@ func SaveCurrentConfig(file string) error {
 	return Save(file, config)
 }
 
-func Exist(file string) bool {
+func exist(file string) bool {
 	_, err := os.Stat(file)
 	if err == nil {
 		return true

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -4,9 +4,18 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/muesli/beehive/bees"
+	gap "github.com/muesli/go-app-paths"
 )
+
+const appName = "beehive"
+const cfgFileName = "beehive.conf"
+
+// This can be easily replaced in tests so we can test without using
+// the real search paths
+var searchPaths = defaultSearchPaths
 
 // Config contains an entire configuration set for Beehive
 type Config struct {
@@ -15,16 +24,68 @@ type Config struct {
 	Chains  []bees.Chain
 }
 
+// DefaultPath returns Beehive's default config path
+//
+// The path returned is OS dependant. If there's an error
+// while trying to figure out the OS dependant path, "beehive.conf"
+// in the current working dir is returned.
+func DefaultPath() string {
+	userScope := gap.NewScope(gap.User, appName)
+	path, err := userScope.ConfigPath(cfgFileName)
+	if err != nil {
+		return cfgFileName
+	}
+
+	return path
+}
+
+func defaultSearchPaths() []string {
+	userScope := gap.NewScope(gap.User, appName)
+	paths := []string{}
+	userCfg, err := userScope.ConfigPath(cfgFileName)
+	if err == nil {
+		paths = append(paths, userCfg)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+	return append(paths, filepath.Join(cwd, cfgFileName))
+}
+
+// FindUserConfigPath tries to find the config file.
+//
+// If a config file is found in the current working directory, that's returned.
+// Otherwise we try to locate it following an OS dependant:
+//
+// Unix:
+//   - ~/.config/app/filename.conf
+// macOS:
+//   - ~/Library/Preferences/app/filename.conf
+// Windows:
+//   - %LOCALAPPDATA%/app/Config/filename.conf
+func FindUserConfigPath() string {
+	path := ""
+	for _, sPath := range searchPaths() {
+		if Exist(sPath) {
+			path = sPath
+			break
+		}
+	}
+
+	return path
+}
+
 // Loads chains from config
 func LoadConfig(file string) (Config, error) {
-	var config Config
+	config := Config{}
 
 	j, err := ioutil.ReadFile(file)
 	if err != nil {
 		return config, err
 	}
 
-	config = Config{}
 	err = json.Unmarshal(j, &config)
 	if err != nil {
 		return config, err
@@ -35,6 +96,11 @@ func LoadConfig(file string) (Config, error) {
 
 // Saves chains to config
 func SaveConfig(file string, c Config) error {
+	cfgDir := filepath.Dir(file)
+	if !Exist(cfgDir) {
+		os.MkdirAll(cfgDir, 0755)
+	}
+
 	j, err := json.MarshalIndent(c, "", "  ")
 	if err == nil {
 		err = ioutil.WriteFile(file, j, 0644)
@@ -52,9 +118,9 @@ func SaveCurrentConfig(file string) error {
 }
 
 func Exist(file string) bool {
-	if _, err := os.Stat(file); os.IsNotExist(err) {
-		return false
+	_, err := os.Stat(file)
+	if err == nil {
+		return true
 	}
-
-	return true
+	return false
 }

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -23,7 +23,7 @@ func TestLoad(t *testing.T) {
 	}
 }
 
-func TestSaveConfig(t *testing.T) {
+func TestSave(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "example")
 	if err != nil {
 		t.Error("Could not create temp file")
@@ -42,7 +42,7 @@ func TestSaveConfig(t *testing.T) {
 		t.Errorf("Failed to save the config to %s", configFile)
 	}
 
-	if !Exist(configFile) {
+	if !exist(configFile) {
 		t.Error("Configuration file wasn't saved")
 	}
 
@@ -52,7 +52,7 @@ func TestSaveConfig(t *testing.T) {
 	}
 }
 
-func TestSaveCurrentConfig(t *testing.T) {
+func TestSaveCurrent(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "example")
 	if err != nil {
 		t.Error("Could not create temp file")
@@ -60,7 +60,7 @@ func TestSaveCurrentConfig(t *testing.T) {
 	defer os.Remove(tmpfile.Name()) // clean up
 
 	t.Run("configFile empty", func(t *testing.T) {
-		err = SaveCurrentConfig("")
+		err = SaveCurrent("")
 		if err == nil {
 			t.Error("Configuration file should not be saved")
 		}
@@ -68,7 +68,7 @@ func TestSaveCurrentConfig(t *testing.T) {
 
 	t.Run("configFile tmpfile", func(t *testing.T) {
 		configFile := tmpfile.Name()
-		err = SaveCurrentConfig(configFile)
+		err = SaveCurrent(configFile)
 		if err != nil {
 			t.Error("Configuration file should have been saved")
 		}

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -45,6 +45,11 @@ func TestSaveConfig(t *testing.T) {
 	if !Exist(configFile) {
 		t.Error("Configuration file wasn't saved")
 	}
+
+	err = SaveConfig(filepath.Join(os.TempDir(), "fooconf/beehive.conf"), testConf)
+	if err != nil {
+		t.Errorf("Failed to create intermediate directories when saving config")
+	}
 }
 
 func TestSaveCurrentConfig(t *testing.T) {
@@ -68,4 +73,35 @@ func TestSaveCurrentConfig(t *testing.T) {
 			t.Error("Configuration file should have been saved")
 		}
 	})
+}
+
+func TestFindUserConfigPath(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "example")
+	if err != nil {
+		t.Error("Could not create temp file")
+	}
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	searchPaths = func() []string {
+		return []string{"foobar", "testdata/beehive.conf"}
+	}
+
+	if FindUserConfigPath() != "testdata/beehive.conf" {
+		t.Error("Invalid config file from search path returned")
+	}
+
+	searchPaths = func() []string {
+		return []string{tmpfile.Name(), "testdata/beehive.conf"}
+	}
+
+	if FindUserConfigPath() != tmpfile.Name() {
+		t.Error("Invalid config file from search path returned")
+	}
+}
+
+func TestDefaultPath(t *testing.T) {
+	dir, _ := os.UserConfigDir()
+	if DefaultPath() != filepath.Join(dir, "beehive", "beehive.conf") {
+		t.Error("Error returning default config file path")
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -56,13 +56,13 @@ require (
 	github.com/mattn/go-mastodon v0.0.3
 	github.com/mattn/go-xmpp v0.0.0-20190124093244-6093f50721ed
 	github.com/minio/minio-go v6.0.14+incompatible
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474 // indirect
 	github.com/mrexodia/wray v0.0.0-20160318003008-78a2c1f284ff // indirect
 	github.com/muesli/clusters v0.0.0-20190807044042-ba9c57dd9228 // indirect
 	github.com/muesli/gamut v0.0.0-20190807050624-0d3f7d26a44e
+	github.com/muesli/go-app-paths v0.2.1
 	github.com/muesli/go-pkg-rss v0.0.0-20180307042412-3bef0f3126ec
 	github.com/muesli/go-pkg-xmlx v0.0.0-20151201012946-76f54ee73233 // indirect
 	github.com/muesli/go.hue v0.0.0-20140802040715-8aefcc693caf

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/muesli/clusters v0.0.0-20190807044042-ba9c57dd9228 h1:JNZ3Ev2fzCgkhtR
 github.com/muesli/clusters v0.0.0-20190807044042-ba9c57dd9228/go.mod h1:mw5KDqUj0eLj/6DUNINLVJNoPTFkEuGMHtJsXLviLkY=
 github.com/muesli/gamut v0.0.0-20190807050624-0d3f7d26a44e h1:039bFbhxSzy9DDVLPT36bz5hG3PG74Y8qrGMXea0iS8=
 github.com/muesli/gamut v0.0.0-20190807050624-0d3f7d26a44e/go.mod h1:qOhbxUcDlplFAT1ULq47hrHOCw1CJoqvbsMeEu6/4mU=
+github.com/muesli/go-app-paths v0.2.1 h1:Qi+2igkDX2aPqyRddp7P0sMQIBwBqhkfQfNcjdGjL6Y=
+github.com/muesli/go-app-paths v0.2.1/go.mod h1:SxS3Umca63pcFcLtbjVb+J0oD7cl4ixQWoBKhGEtEho=
 github.com/muesli/go-pkg-rss v0.0.0-20180307042412-3bef0f3126ec h1:HyAZt1/sm0/stsv+GxzMr1QDYqwXIQS0aFCViIsx6E0=
 github.com/muesli/go-pkg-rss v0.0.0-20180307042412-3bef0f3126ec/go.mod h1:asRQ3kBaWU1Dtidbg30iByH0cWAE9ZzVBHbozpVBtCM=
 github.com/muesli/go-pkg-xmlx v0.0.0-20151201012946-76f54ee73233 h1:BpRRQx7DiGCvj3G9ioAnzesXNaF+TXZO1Y7Za1GzC9A=


### PR DESCRIPTION
This changes Beehive's behavior.

When writting the config file for the first time
(i.e. if beehive was run without a config), the file will be written to
`~/.config/beehive/beehive.conf` (OS dependant) instead of the current
directory.

Loading the config from the current directory, if available, is still
preferred, so that doesn't change.

Fixes #283