### PR TITLE
Reference localhost instead of example.com

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - beehive-conf:/conf
     environment:
       # be sure not to pass quotes, just the bare url
-      - CANONICAL_URL=https://beehive.example.com
+      - CANONICAL_URL=http://localhost:8181
 
 volumes:
   beehive-conf:


### PR DESCRIPTION
This particular example runs on the localhost and should reference it 
accordingly for ease of use.