### PR TITLE
openweathermap bee: set current weather context

### DIFF
--- a/bees/openweathermapbee/event.go
+++ b/bees/openweathermapbee/event.go
@@ -29,6 +29,9 @@ import (
 
 // TriggerCurrentWeatherEvent triggers all current weather events
 func (mod *OpenweathermapBee) TriggerCurrentWeatherEvent() {
+
+	mod.ContextSet("current", mod.current)
+
 	ev := bees.Event{
 		Bee:  mod.Name(),
 		Name: "current_weather",


### PR DESCRIPTION
This makes it easier to retrieve the current weather from other actions
as long as you have the weather bee running and a chain that periodically
gets the current weather (with the cron bee for example).

Example templates:

```
"Weather in {{.context.weather.current.Name}}: {{(index .context.weather.current.Weather 0).Description}}, {{.context.weather.current.Main.Temp}} ºC"
```

Would print something like:

```
Weather in Barcelona: few clouds, 22.57 ºC
```