### PR TITLE
openweathermap: Handle multiple locations in context

### DIFF
--- a/bees/openweathermapbee/event.go
+++ b/bees/openweathermapbee/event.go
@@ -27,10 +27,19 @@ import (
 	owm "github.com/briandowns/openweathermap"
 )
 
+type weatherContext = map[int]*owm.CurrentWeatherData
+
 // TriggerCurrentWeatherEvent triggers all current weather events
 func (mod *OpenweathermapBee) TriggerCurrentWeatherEvent() {
 
-	mod.ContextSet("current", mod.current)
+	cc := mod.ContextValue("current")
+	if cc != nil {
+		(cc.(weatherContext))[mod.current.ID] = mod.current
+	} else {
+		cc = weatherContext{}
+		(cc.(weatherContext))[mod.current.ID] = mod.current
+		mod.ContextSet("current", cc)
+	}
 
 	ev := bees.Event{
 		Bee:  mod.Name(),


### PR DESCRIPTION
Extends https://github.com/muesli/beehive/pull/311 by adding support
to store multiple locations in the Bee context, at the expense of making
it a bit more complex to retrieve the info from a template.

Something like:

```
"Weather in {{(index .context.weather.current 3128760).Name}}: ..."
```

Where `3128760` is the OpenWeatherMap ID corresponding to one of the
locations stored in the context while retrieving the weather.