### PR TITLE
Telegram bee updates

### DIFF
--- a/bees/telegrambee/README.md
+++ b/bees/telegrambee/README.md
@@ -12,15 +12,23 @@ Bee options:
     "Name": "telegram",
     "Class": "telegrambee",
     "Description": "Telegram bot bee",
-    "Options": [{
-        "Name": "apiKey",
-        "Value": "file:///Users/lalotone/.telegramapi"
-    }]
+    "Options": [
+        {
+            "Name": "api_key",
+            "Value": "file:///Users/lalotone/.telegramapi"
+        },
+        {
+            "Name": "formatting_enabled",
+            "Value": false
+        }
+    ]
 }]
 ```
 
-**apiKey**: [Telegram bot](https://core.telegram.org/bots) API Key. Can be added
+**api_key**: [Telegram bot](https://core.telegram.org/bots) API Key. Can be added
 to the recipe, via environment variable (`env://MY_API_KEY`) or read from a file (`file:///Users/lalotone/.telegram_key`)
+
+**formatting_enabled**: Enable [HTML message formatting](https://core.telegram.org/bots/api#html-style).
 
 ## Credits
 

--- a/bees/telegrambee/telegrambee.go
+++ b/bees/telegrambee/telegrambee.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	telegram "github.com/tucnak/telebot"
+	telegram "gopkg.in/tucnak/telebot.v2"
 
 	"github.com/muesli/beehive/bees"
 )
@@ -103,7 +103,7 @@ func (mod *TelegramBee) Run(eventChan chan bees.Event) {
 				{
 					Name:  "user_id",
 					Type:  "string",
-					Value: strconv.Itoa(m.OriginalSender.ID),
+					Value: strconv.Itoa(m.Sender.ID),
 				},
 				{
 					Name:  "timestamp",
@@ -112,6 +112,7 @@ func (mod *TelegramBee) Run(eventChan chan bees.Event) {
 				},
 			},
 		}
+		mod.LogDebugf("Sending event: %+v", ev)
 		eventChan <- ev
 	})
 

--- a/bees/telegrambee/telegrambee.go
+++ b/bees/telegrambee/telegrambee.go
@@ -56,6 +56,7 @@ func (mod *TelegramBee) Action(action bees.Action) []bees.Placeholder {
 		action.Options.Bind("chat_id", &chatID)
 		action.Options.Bind("text", &text)
 
+		mod.LogDebugf("Sending text message: text: '%s' chatid: '%+v'", text, chatID)
 		cid, err := strconv.ParseInt(chatID, 10, 64)
 		if err != nil {
 			panic("Invalid telegram chat ID")

--- a/bees/telegrambee/telegrambee.go
+++ b/bees/telegrambee/telegrambee.go
@@ -43,6 +43,8 @@ type TelegramBee struct {
 	apiKey string
 	// Bot API client
 	bot *telegram.Bot
+	// HTML formatting enabled
+	formattingEnabled bool
 }
 
 // Action triggers the action passed to it.
@@ -56,13 +58,18 @@ func (mod *TelegramBee) Action(action bees.Action) []bees.Placeholder {
 		action.Options.Bind("chat_id", &chatID)
 		action.Options.Bind("text", &text)
 
-		mod.LogDebugf("Sending text message: text: '%s' chatid: '%+v'", text, chatID)
 		cid, err := strconv.ParseInt(chatID, 10, 64)
 		if err != nil {
 			panic("Invalid telegram chat ID")
 		}
 
-		_, err = mod.bot.Send(&telegram.Chat{ID: cid}, text)
+		parseMode := ""
+		if mod.formattingEnabled {
+			parseMode = telegram.ModeHTML
+		}
+
+		mod.LogDebugf("Sending text message: text: '%s' chatid: '%+v', formatting: %s", text, chatID, parseMode)
+		_, err = mod.bot.Send(&telegram.Chat{ID: cid}, text, parseMode)
 		if err != nil {
 			mod.Logf("Error sending message %v", err)
 		}
@@ -125,6 +132,7 @@ func (mod *TelegramBee) ReloadOptions(options bees.BeeOptions) {
 
 	apiKey := getAPIKey(&options)
 	mod.apiKey = apiKey
+	options.Bind("formatting_enabled", &mod.formattingEnabled)
 }
 
 // Gets the Bot's API key from a file, the recipe config or the

--- a/bees/telegrambee/telegrambeefactory.go
+++ b/bees/telegrambee/telegrambeefactory.go
@@ -73,6 +73,13 @@ func (factory *TelegramBeeFactory) Options() []bees.BeeOptionDescriptor {
 			Type:        "string",
 			Mandatory:   true,
 		},
+		{
+			Name:        "formatting_enabled",
+			Description: "Enable HTML text formatting",
+			Type:        "bool",
+			Default:     false,
+			Mandatory:   false,
+		},
 	}
 	return opts
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/go-mail/mail v2.3.1+incompatible
 	github.com/go-redis/redis v6.15.6+incompatible
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
-	github.com/go-telegram-bot-api/telegram-bot-api v1.0.1-0.20200319042609-5e339ed016b0
 	github.com/golang/mock v1.2.0 // indirect
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/google/go-github v17.0.0+incompatible
@@ -58,6 +57,7 @@ require (
 	github.com/mattn/go-mastodon v0.0.3
 	github.com/mattn/go-xmpp v0.0.0-20190124093244-6093f50721ed
 	github.com/minio/minio-go v6.0.14+incompatible
+	github.com/mitchellh/hashstructure v1.0.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474 // indirect
@@ -90,8 +90,8 @@ require (
 	github.com/sromku/go-gitter v0.0.0-20170828210750-70f7030a94a6
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
-	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
+	github.com/tucnak/telebot v2.0.0+incompatible
 	github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 // indirect
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/mattn/go-mastodon v0.0.3
 	github.com/mattn/go-xmpp v0.0.0-20190124093244-6093f50721ed
 	github.com/minio/minio-go v6.0.14+incompatible
-	github.com/mitchellh/hashstructure v1.0.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474 // indirect
@@ -91,7 +90,6 @@ require (
 	github.com/ssor/bom v0.0.0-20170718123548-6386211fdfcf // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
-	github.com/tucnak/telebot v2.0.0+incompatible
 	github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 // indirect
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
@@ -102,5 +100,6 @@ require (
 	gopkg.in/ini.v1 v1.42.0 // indirect
 	gopkg.in/mail.v2 v2.3.1 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
+	gopkg.in/tucnak/telebot.v2 v2.3.1
 	layeh.com/gumble v0.0.0-20180508205105-1ea1159c4956
 )

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/emicklei/go-restful v2.9.3+incompatible h1:2OwhVdhtzYUp5P5wuGsVDPagKS
 github.com/emicklei/go-restful v2.9.3+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/flashmob/go-guerrilla v0.0.0-20190502151606-07043ae76e81 h1:45gIhMM+MtaoDrhBYFCSjYiQDNr9r6NNyGqzwPfKGco=
-github.com/flashmob/go-guerrilla v0.0.0-20190502151606-07043ae76e81/go.mod h1:ZT9TRggRsSY4ZVndoyx8TRUxi3tM/nOYtKWKDX94H0I=
 github.com/flashmob/go-guerrilla v1.6.1 h1:MLkqzRFUJveVAWuQ3s2MNPTAWbvXLt8EFsBoraS6qHA=
 github.com/flashmob/go-guerrilla v1.6.1/go.mod h1:ZT9TRggRsSY4ZVndoyx8TRUxi3tM/nOYtKWKDX94H0I=
 github.com/fluffle/goirc v1.0.1 h1:YHBfWIXSFgABz8dbijvOIKucFejnbHdk78+r2z/6B/Q=
@@ -77,10 +75,6 @@ github.com/go-redis/redis v6.15.6+incompatible h1:H9evprGPLI8+ci7fxQx6WNZHJSb7be
 github.com/go-redis/redis v6.15.6+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
-github.com/go-telegram-bot-api/telegram-bot-api v1.0.1-0.20200319042609-5e339ed016b0 h1:MMufjch8yWKRo67mc+HdMseaUlF1UAwngldBRB/lgAs=
-github.com/go-telegram-bot-api/telegram-bot-api v1.0.1-0.20200319042609-5e339ed016b0/go.mod h1:lDm2E64X4OjFdBUA4hlN4mEvbSitvhJdKw7rsA8KHgI=
-github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible h1:2cauKuaELYAEARXRkq2LrJ0yDDv1rW7+wrTEdVL3uaU=
-github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible/go.mod h1:qf9acutJ8cwBUhm1bqgz6Bei9/C/c93FPDljKWwsOgM=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -154,6 +148,8 @@ github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJ
 github.com/minio/minio-go v6.0.14+incompatible/go.mod h1:7guKYtitv8dktvNUGrhzmNlA5wrAABTQXCoesZdFQO8=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
+github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
@@ -177,8 +173,6 @@ github.com/muesli/go.hue v0.0.0-20140802040715-8aefcc693caf h1:LxZj9OgYtTw5bQWoH
 github.com/muesli/go.hue v0.0.0-20140802040715-8aefcc693caf/go.mod h1:kbCdPkiPQGNQW+m9a1XHIrOCT4/FtfpqBF2bVkwZjMg=
 github.com/muesli/goefa v0.0.0-20180507204150-08d8ee2555d2 h1:A0yDQZg4PVcBvzH9IYGydylu0ytfiTK8LaHOH5eJrLY=
 github.com/muesli/goefa v0.0.0-20180507204150-08d8ee2555d2/go.mod h1:cbhVWIL28EF8sTH71/qsU+TeEEmYC33MES0J7Ul0TFI=
-github.com/muesli/gominatim v0.1.0 h1:WFfXBLa/tXAhCbG2WrVfUN+l3WSP7rDRpYxe0tekvz0=
-github.com/muesli/gominatim v0.1.0/go.mod h1:4/L0h2Z155HXvPTnRdks5EQr16e2yH1EM2lGReeQCwg=
 github.com/muesli/gominatim v0.1.1-0.20200501135808-f6af22631c72 h1:8Fq6qkEpVNhDM8wKRE5vYfKeasp6dZKfpNWcD+c+5Pw=
 github.com/muesli/gominatim v0.1.1-0.20200501135808-f6af22631c72/go.mod h1:4/L0h2Z155HXvPTnRdks5EQr16e2yH1EM2lGReeQCwg=
 github.com/muesli/kmeans v0.0.0-20190917235210-80dfc71e6c5a h1:TfqSfRTR/uTo2h3AfuXaeWm+a6DH7mYSlfQkNhxnxUk=
@@ -248,10 +242,10 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/technoweenie/multipartstreamer v1.0.1 h1:XRztA5MXiR1TIRHxH2uNxXxaIkKQDeX7m2XsSOlQEnM=
-github.com/technoweenie/multipartstreamer v1.0.1/go.mod h1:jNVxdtShOxzAsukZwTSw6MDx5eUJoiEBsSvzDU9uzog=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
+github.com/tucnak/telebot v2.0.0+incompatible h1:Amnb+h23aEnfKSDqFKU/R1qGSGgnS78Hm56lLVVQL2A=
+github.com/tucnak/telebot v2.0.0+incompatible/go.mod h1:TCLoYDyssqVcjhkdyYu+He6eldK40im537vXoex2LM0=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/wcharczuk/go-chart v2.0.1+incompatible h1:0pz39ZAycJFF7ju/1mepnk26RLVLBCWz1STcD3doU0A=
 github.com/wcharczuk/go-chart v2.0.1+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=

--- a/go.sum
+++ b/go.sum
@@ -148,8 +148,6 @@ github.com/minio/minio-go v6.0.14+incompatible h1:fnV+GD28LeqdN6vT2XdGKW8Qe/IfjJ
 github.com/minio/minio-go v6.0.14+incompatible/go.mod h1:7guKYtitv8dktvNUGrhzmNlA5wrAABTQXCoesZdFQO8=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
-github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
@@ -242,10 +240,10 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
-github.com/tucnak/telebot v2.0.0+incompatible h1:Amnb+h23aEnfKSDqFKU/R1qGSGgnS78Hm56lLVVQL2A=
-github.com/tucnak/telebot v2.0.0+incompatible/go.mod h1:TCLoYDyssqVcjhkdyYu+He6eldK40im537vXoex2LM0=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/wcharczuk/go-chart v2.0.1+incompatible h1:0pz39ZAycJFF7ju/1mepnk26RLVLBCWz1STcD3doU0A=
 github.com/wcharczuk/go-chart v2.0.1+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=
@@ -310,6 +308,8 @@ gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce h1:xcEWjVhvbDy+nHP67nPDDpbYrY
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/tucnak/telebot.v2 v2.3.1 h1:ux26aeidIT1RcqOiTjZtNEdAgXoohc/CKM6imBSkzbw=
+gopkg.in/tucnak/telebot.v2 v2.3.1/go.mod h1:t+KVAiqFsG9ZDF0hz1ZPFTyENtlrDrDS3qmRRqhICBg=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=


### PR DESCRIPTION
This a backwards compatible change, existing installs shouldn't note the difference.

## Changes

### Switch to [tucnak/telebot](https://github.com/tucnak/telebot)

Nice, cleaner API and they seem to be doing a better job at releasing software.

### Optional HTML parsing for messages

New option to enable [HTML formatting](https://core.telegram.org/bots/api#html-style), implementing a feature request in https://github.com/muesli/beehive/issues/308 (disabled by default). cc @it-parasite