### PR TITLE
Add bash and python2 for CMD hive usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN make embed
 FROM alpine
 
 RUN apk update && \
-    apk add --no-cache ca-certificates tzdata && \
+    apk add --no-cache ca-certificates tzdata bash python2 && \
     update-ca-certificates
 
 COPY --from=builder /go/beehive/beehive /go/bin/beehive


### PR DESCRIPTION
The default beehive docker image shell (busybox) leaves a lot to be desired when it comes to executing commands via the CMD hive.  This PR adds bash and python2 to the installed packages to allow them to be used in CMD.