### PR TITLE
Support parse_mode for telegram

### DIFF
--- a/bees/telegrambee/telegrambeefactory.go
+++ b/bees/telegrambee/telegrambeefactory.go
@@ -22,7 +22,11 @@
 
 package telegrambee
 
-import "github.com/muesli/beehive/bees"
+import (
+	"fmt"
+
+	"github.com/muesli/beehive/bees"
+)
 
 // TelegramBeeFactory is a factory for TelegramBees.
 type TelegramBeeFactory struct {
@@ -129,6 +133,12 @@ func (factory *TelegramBeeFactory) Actions() []bees.ActionDescriptor {
 				Description: "Content of the message",
 				Type:        "string",
 				Mandatory:   true,
+			},
+			{
+				Name:        "parse_mode",
+				Description: fmt.Sprintf("Parse mode (%s, %s, or leave empty)", ModeHTML, ModeMarkdown),
+				Type:        "string",
+				Mandatory:   false,
 			},
 		},
 	}}


### PR DESCRIPTION
Telegram supports [formatting options](https://core.telegram.org/bots/api#formatting-options) which can be specified via `parse_mode` field. It is a must-have thing to have nice messages and `telegram-bot-api` supports it.

The PR makes it possible to specify `parse_mode` when configuring Telegram Action.