### PR TITLE
Add a few helpful template filters

### DIFF
--- a/templatehelper/templatehelper.go
+++ b/templatehelper/templatehelper.go
@@ -75,15 +75,28 @@ var (
 			return items[len(items)-1], nil
 		},
 		"ContainsAny": func(target, subs string, other ...string) bool {
+			// contains any symbol from the given string
 			if len(other) == 0 {
 				return strings.ContainsAny(target, subs)
 			}
+			// contains any of the given strings
 			for _, another := range other {
 				if strings.Contains(target, another) {
 					return true
 				}
 			}
 			return strings.Contains(target, subs)
+		},
+		"ContainsAll": func(target string, other ...string) (bool, error) {
+			if len(other) == 0 {
+				return false, errors.New("to find substring in a string, use Contains")
+			}
+			for _, another := range other {
+				if !strings.Contains(target, another) {
+					return false, nil
+				}
+			}
+			return true, nil
 		},
 		// strings functions
 		"Compare":      strings.Compare, // 1.5+ only

--- a/templatehelper/templatehelper.go
+++ b/templatehelper/templatehelper.go
@@ -34,6 +34,9 @@ import (
 // FuncMap contains a few convenient template helpers
 var (
 	FuncMap = template.FuncMap{
+		"Array": func(values ...interface{}) []interface{} {
+			return values
+		},
 		"JSON": func(values ...interface{}) htmlTemplate.JS {
 			json, _ := json.Marshal(values)
 			return htmlTemplate.JS(json)

--- a/templatehelper/templatehelper.go
+++ b/templatehelper/templatehelper.go
@@ -74,10 +74,20 @@ var (
 			}
 			return items[len(items)-1], nil
 		},
+		"ContainsAny": func(target, subs string, other ...string) bool {
+			if len(other) == 0 {
+				return strings.ContainsAny(target, subs)
+			}
+			for _, another := range other {
+				if strings.Contains(target, another) {
+					return true
+				}
+			}
+			return strings.Contains(target, subs)
+		},
 		// strings functions
 		"Compare":      strings.Compare, // 1.5+ only
 		"Contains":     strings.Contains,
-		"ContainsAny":  strings.ContainsAny,
 		"Count":        strings.Count,
 		"EqualFold":    strings.EqualFold,
 		"HasPrefix":    strings.HasPrefix,

--- a/templatehelper/templatehelper_test.go
+++ b/templatehelper/templatehelper_test.go
@@ -104,6 +104,11 @@ func Test_FuncMap_Positive(t *testing.T) {
 		{`{{TrimPrefix "123hello123" "231"}}`, "123hello123"},
 		{`{{TrimSuffix "123hello123" "123"}}`, "123hello"},
 		{`{{TrimSuffix "123hello123" "231"}}`, "123hello123"},
+
+		// OTHER FILTERS //
+		{`{{Array "oh" "hi" "mark"}}`, "[oh hi mark]"},
+		{`{{Count "why do you cry willy why do you cry why willy why" "why"}}`, "4"},
+		// ...
 	}
 
 	for _, tcase := range cases {

--- a/templatehelper/templatehelper_test.go
+++ b/templatehelper/templatehelper_test.go
@@ -34,8 +34,13 @@ func Test_FuncMap_Positive(t *testing.T) {
 		{`{{if Contains "123" "2"}}ok{{end}}`, "ok"},
 		{`{{if Contains "123" "4"}}ok{{end}}`, ""},
 
+		// contains any of symbols
 		{`{{if ContainsAny "123" "24"}}ok{{end}}`, "ok"},
 		{`{{if ContainsAny "123" "45"}}ok{{end}}`, ""},
+		// contains any of strings
+		{`{{if ContainsAny "123456" "23" "78"}}ok{{end}}`, "ok"},
+		{`{{if ContainsAny "123456" "78" "23"}}ok{{end}}`, "ok"},
+		{`{{if ContainsAny "123456" "46" "24"}}ok{{end}}`, ""},
 
 		{`{{if EqualFold "HellO" "hello"}}ok{{end}}`, "ok"},
 		{`{{if EqualFold "ПривеТ" "привет"}}ok{{end}}`, "ok"},

--- a/templatehelper/templatehelper_test.go
+++ b/templatehelper/templatehelper_test.go
@@ -21,12 +21,12 @@ func Test_FuncMap_Positive(t *testing.T) {
 		text     string
 		expected string
 	}{
-		// sanity checks
+		// SANITY CHECKS //
 
 		{`{{if true}}ok{{end}}`, "ok"},
 		{`{{if false}}ok{{end}}`, ""},
 
-		// boolean filters
+		// BOOLEAN FILTERS //
 
 		{`{{if Matches "123" "\\d+"}}ok{{end}}`, "ok"},
 		{`{{if Matches "hello" "\\d+"}}ok{{end}}`, ""},
@@ -42,6 +42,10 @@ func Test_FuncMap_Positive(t *testing.T) {
 		{`{{if ContainsAny "123456" "78" "23"}}ok{{end}}`, "ok"},
 		{`{{if ContainsAny "123456" "46" "24"}}ok{{end}}`, ""},
 
+		{`{{if ContainsAll "123456" "23" "56"}}ok{{end}}`, "ok"},
+		{`{{if ContainsAll "123456" "23" "78"}}ok{{end}}`, ""},
+		{`{{if ContainsAll "123456" "24" "35"}}ok{{end}}`, ""},
+
 		{`{{if EqualFold "HellO" "hello"}}ok{{end}}`, "ok"},
 		{`{{if EqualFold "ПривеТ" "привет"}}ok{{end}}`, "ok"},
 		{`{{if EqualFold "good" "goed"}}ok{{end}}`, ""},
@@ -52,7 +56,7 @@ func Test_FuncMap_Positive(t *testing.T) {
 		{`{{if HasSuffix "hello" "lo"}}ok{{end}}`, "ok"},
 		{`{{if HasSuffix "hello" "he"}}ok{{end}}`, ""},
 
-		// filters returning a string
+		// FILTERS RETURNING A STRING //
 
 		{`{{JSON 123}}`, "[123]"},
 
@@ -78,7 +82,28 @@ func Test_FuncMap_Positive(t *testing.T) {
 
 		{`{{Replace "1234" "23" "56" -1}}`, "1564"},
 		{`{{Replace "12223" "2" "5" 1}}`, "15223"},
-		// ...
+
+		{`{{Title "aragorn son of arathorn"}}`, "Aragorn Son Of Arathorn"},
+		{`{{Title "ǳ"}}`, "ǲ"},
+
+		{`{{ToTitle "aragorn son of arathorn"}}`, "ARAGORN SON OF ARATHORN"},
+		{`{{ToTitle "ǳ"}}`, "ǲ"},
+
+		{`{{ToLower "Aragorn Son Of Arathorn"}}`, "aragorn son of arathorn"},
+		{`{{ToLower "ǳ"}}`, "ǳ"},
+
+		{`{{ToUpper "Aragorn Son Of Arathorn"}}`, "ARAGORN SON OF ARATHORN"},
+		{`{{ToUpper "ǳ"}}`, "Ǳ"},
+
+		{`{{Trim "-_=oh=hi-mark---=" "=_-"}}`, "oh=hi-mark"},
+		{`{{TrimLeft "-_=oh=hi-mark---=" "=_-"}}`, "oh=hi-mark---="},
+		{`{{TrimRight "-_=oh=hi-mark---=" "=_-"}}`, "-_=oh=hi-mark"},
+		{`{{TrimSpace "  oh hi  mark \\n\\t  "}}`, "oh hi  mark \\n\\t"},
+
+		{`{{TrimPrefix "123hello123" "123"}}`, "hello123"},
+		{`{{TrimPrefix "123hello123" "231"}}`, "123hello123"},
+		{`{{TrimSuffix "123hello123" "123"}}`, "123hello"},
+		{`{{TrimSuffix "123hello123" "231"}}`, "123hello123"},
 	}
 
 	for _, tcase := range cases {


### PR DESCRIPTION
## ContainsAny

I patched `ContainsAny` filter to be able to check if the given string contains any of the given substrings.

For example, this one:

```clojure
{{test or (Contains .title "dephell") (Contains .title "flakehell") (Contains .title "orsinium.dev")}}
```

Can now be transformed into much simpler and shorter expression:

```clojure
{{test ContainsAny .title "dephell" "flakehell" "orsinium.dev"}}
```
If only 2 strings are passed into the filter, it behaves as it used to, checking every symbol from the second string to be represented in the first one. While I cannot imagine a use case for it in beehive, let's keep the backward compatibility. It should be ok because `ContainsAny` looking only for one substring would be the same as just `Contains`.

## ContainsAll

If we have `ContainsAny`, why not to have `ContainsAll`? I've added a new filter to check if a string contains all substrings.

## Array

There is no syntax in the template engine to create an array but some functions accept arrays. It can be emulated with `Split` but it's not nice looking. So, let's make one.

```clojure
{{Array "flakehell" "dephell"}}
```

## More tests

I've added more tests for string functions. Since there is no way to edit the wiki from the master branch (where is it, BTW?), let's at least have the code "self-documented".