### PR TITLE
Fix go-lint violations in `cfg` package

### DIFF
--- a/cfg/aesbackend.go
+++ b/cfg/aesbackend.go
@@ -126,7 +126,10 @@ func (b *AESBackend) Save(config *Config) error {
 	u := config.URL()
 	cfgDir := filepath.Dir(u.Path)
 	if !exist(cfgDir) {
-		os.MkdirAll(cfgDir, 0755)
+		err := os.MkdirAll(cfgDir, 0755)
+		if err != nil {
+			return err
+		}
 	}
 
 	j, err := json.MarshalIndent(config, "", "  ")

--- a/cfg/aesbackend_test.go
+++ b/cfg/aesbackend_test.go
@@ -72,7 +72,7 @@ func TestAESBackendLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Can't create AES backend: %v", err)
 	}
-	conf, err = backend.Load(u)
+	_, err = backend.Load(u)
 	if err != nil {
 		t.Errorf("loading the config file using the environment password should work. %v", err)
 	}
@@ -88,7 +88,7 @@ func TestAESBackendLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Can't create AES backend: %v", err)
 	}
-	conf, err = backend.Load(u)
+	_, err = backend.Load(u)
 	if err == nil || err.Error() != "cipher: message authentication failed" {
 		t.Errorf("loading the config file with an invalid password should fail. %v", err)
 	}
@@ -104,7 +104,7 @@ func TestAESBackendLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Can't create AES backend: %v", err)
 	}
-	conf, err = backend.Load(u)
+	_, err = backend.Load(u)
 	if err != nil {
 		t.Errorf("the password defined in %s should take precedence. %v", PasswordEnvVar, err)
 	}
@@ -113,7 +113,7 @@ func TestAESBackendLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Can't parse crypto URL: %v", err)
 	}
-	conf, err = backend.Load(u)
+	_, err = backend.Load(u)
 	if err == nil || err.Error() != "encrypted configuration header not valid" {
 		t.Errorf("the password defined in %s should take precedence. %v", PasswordEnvVar, err)
 	}
@@ -127,6 +127,9 @@ func TestAESBackendSave(t *testing.T) {
 
 	cwd, _ := os.Getwd()
 	u, err := url.Parse(filepath.Join("crypto://"+testPassword+"@", cwd, "testdata", "beehive-crypto.conf"))
+	if err != nil {
+		t.Error("cannot parse config url")
+	}
 	backend, _ := NewAESBackend(u)
 	c, err := backend.Load(u)
 	if err != nil {
@@ -136,7 +139,13 @@ func TestAESBackendSave(t *testing.T) {
 	// Save the config file to a new absolute path using a URL
 	p := filepath.Join(tmpdir, "beehive-crypto.conf")
 	u, err = url.Parse("crypto://" + testPassword + "@" + p)
-	c.SetURL(u.String())
+	if err != nil {
+		t.Error("cannot parse config url")
+	}
+	err = c.SetURL(u.String())
+	if err != nil {
+		t.Error("cannot set url")
+	}
 	backend, _ = NewAESBackend(u)
 	err = backend.Save(c)
 	if err != nil {

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -15,6 +15,13 @@ const appName = "beehive"
 
 var cfgFileName = "beehive.conf"
 
+type Format int
+
+const (
+	FormatJSON Format = 0
+	FormatYAML Format = iota
+)
+
 // Config contains an entire configuration set for Beehive
 type Config struct {
 	Bees    []bees.BeeConfig

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -183,9 +183,5 @@ func Lookup() string {
 
 func exist(file string) bool {
 	_, err := os.Stat(file)
-	if err == nil {
-		return true
-	}
-
-	return false
+	return err == nil
 }

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -15,13 +15,6 @@ const appName = "beehive"
 
 var cfgFileName = "beehive.conf"
 
-type Format int
-
-const (
-	FormatJSON Format = 0
-	FormatYAML Format = iota
-)
-
 // Config contains an entire configuration set for Beehive
 type Config struct {
 	Bees    []bees.BeeConfig

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -26,6 +26,9 @@ func TestNew(t *testing.T) {
 	cwd, _ := os.Getwd()
 	p := filepath.Join(cwd, "testdata/beehive-crypto.conf")
 	conf, err = New(p)
+	if err != nil {
+		panic(err)
+	}
 	if _, ok := conf.Backend().(*AESBackend); !ok {
 		t.Errorf("Backend for '%s' should be an AESBackend", p)
 	}
@@ -38,12 +41,12 @@ func TestNew(t *testing.T) {
 		t.Error("Backend for 'mem:' should be a MemoryBackend")
 	}
 
-	conf, err = New("c:\\foobar")
+	_, err = New("c:\\foobar")
 	if err == nil {
 		t.Error("Not a valid URL, should return an error")
 	}
 
-	conf, err = New("")
+	_, err = New("")
 	if err == nil {
 		t.Error("Not a valid URL, should return an error")
 	}

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -9,8 +9,7 @@ import (
 func TestNew(t *testing.T) {
 	conf, err := New("/foobar")
 	if err != nil {
-		t.Error("cannot create config from path")
-		t.FailNow()
+		t.Fatal("cannot create config from path")
 	}
 	if _, ok := conf.Backend().(*FileBackend); !ok {
 		t.Error("Backend for '/foobar' should be a FileBackend")
@@ -18,8 +17,7 @@ func TestNew(t *testing.T) {
 
 	conf, err = New("file:///foobar")
 	if err != nil {
-		t.Error("cannot create config from file:// path")
-		t.FailNow()
+		t.Fatal("cannot create config from file:// path")
 	}
 	if _, ok := conf.Backend().(*FileBackend); !ok {
 		t.Error("Backend for 'file:///foobar' should be a FileBackend")
@@ -29,7 +27,7 @@ func TestNew(t *testing.T) {
 	p := filepath.Join(cwd, "testdata/beehive-crypto.conf")
 	conf, err = New(p)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	if _, ok := conf.Backend().(*AESBackend); !ok {
 		t.Errorf("Backend for '%s' should be an AESBackend", p)
@@ -37,8 +35,7 @@ func TestNew(t *testing.T) {
 
 	conf, err = New("mem:")
 	if err != nil {
-		t.Error("cannot create config from memory")
-		t.FailNow()
+		t.Fatal("cannot create config from memory")
 	}
 	if _, ok := conf.Backend().(*MemBackend); !ok {
 		t.Error("Backend for 'mem:' should be a MemoryBackend")
@@ -58,7 +55,7 @@ func TestNew(t *testing.T) {
 func TestLoad(t *testing.T) {
 	conf, err := New("mem://")
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	err = conf.Load()
 	if err != nil {

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -9,7 +9,8 @@ import (
 func TestNew(t *testing.T) {
 	conf, err := New("/foobar")
 	if err != nil {
-		panic(err)
+		t.Error("cannot create config from path")
+		t.FailNow()
 	}
 	if _, ok := conf.Backend().(*FileBackend); !ok {
 		t.Error("Backend for '/foobar' should be a FileBackend")
@@ -17,7 +18,8 @@ func TestNew(t *testing.T) {
 
 	conf, err = New("file:///foobar")
 	if err != nil {
-		panic(err)
+		t.Error("cannot create config from file:// path")
+		t.FailNow()
 	}
 	if _, ok := conf.Backend().(*FileBackend); !ok {
 		t.Error("Backend for 'file:///foobar' should be a FileBackend")
@@ -35,7 +37,8 @@ func TestNew(t *testing.T) {
 
 	conf, err = New("mem:")
 	if err != nil {
-		panic(err)
+		t.Error("cannot create config from memory")
+		t.FailNow()
 	}
 	if _, ok := conf.Backend().(*MemBackend); !ok {
 		t.Error("Backend for 'mem:' should be a MemoryBackend")

--- a/cfg/filebackend.go
+++ b/cfg/filebackend.go
@@ -44,7 +44,10 @@ func (fs *FileBackend) Load(u *url.URL) (*Config, error) {
 func (fs *FileBackend) Save(config *Config) error {
 	cfgDir := filepath.Dir(config.URL().Path)
 	if !exist(cfgDir) {
-		os.MkdirAll(cfgDir, 0755)
+		err := os.MkdirAll(cfgDir, 0755)
+		if err != nil {
+			return err
+		}
 	}
 
 	j, err := json.MarshalIndent(config, "", "  ")

--- a/cfg/filebackend_test.go
+++ b/cfg/filebackend_test.go
@@ -88,9 +88,13 @@ func TestFileSave(t *testing.T) {
 
 	// Save the config file to a new absolute path using a regular path
 	p = filepath.Join(tmpdir, "beehive.conf")
-	_, err = url.Parse(p)
+	u, err = url.Parse(p)
 	if err != nil {
 		t.Error("cannot parse config path")
+	}
+	err = c.SetURL(u.String())
+	if err != nil {
+		t.Error("cannot set url")
 	}
 	err = backend.Save(c)
 	if err != nil {

--- a/cfg/filebackend_test.go
+++ b/cfg/filebackend_test.go
@@ -19,6 +19,9 @@ func TestFileLoad(t *testing.T) {
 
 	// try to load the config from a relative path
 	u, err = url.Parse(filepath.Join("testdata", "beehive.conf"))
+	if err != nil {
+		t.Error("cannot parse config path")
+	}
 	backend = NewFileBackend()
 	conf, err := backend.Load(u)
 	if err != nil {
@@ -31,6 +34,9 @@ func TestFileLoad(t *testing.T) {
 	// try to load the config from an absolute path using a URI
 	cwd, _ := os.Getwd()
 	u, err = url.Parse(filepath.Join("file://", cwd, "testdata", "beehive.conf"))
+	if err != nil {
+		t.Error("cannot parse config path")
+	}
 	backend = NewFileBackend()
 	conf, err = backend.Load(u)
 	if err != nil {
@@ -48,6 +54,9 @@ func TestFileSave(t *testing.T) {
 	}
 
 	u, err := url.Parse(filepath.Join("testdata", "beehive.conf"))
+	if err != nil {
+		t.Error("cannot parse config path")
+	}
 	backend := NewFileBackend()
 	c, err := backend.Load(u)
 	if err != nil {
@@ -57,7 +66,13 @@ func TestFileSave(t *testing.T) {
 	// Save the config file to a new absolute path using a URL
 	p := filepath.Join(tmpdir, "beehive.conf")
 	u, err = url.Parse("file://" + p)
-	c.SetURL(u.String())
+	if err != nil {
+		t.Error("cannot parse config path")
+	}
+	err = c.SetURL(u.String())
+	if err != nil {
+		t.Error("cannot set url")
+	}
 	backend = NewFileBackend()
 	err = backend.Save(c)
 	if err != nil {
@@ -73,7 +88,10 @@ func TestFileSave(t *testing.T) {
 
 	// Save the config file to a new absolute path using a regular path
 	p = filepath.Join(tmpdir, "beehive.conf")
-	u, err = url.Parse(p)
+	_, err = url.Parse(p)
+	if err != nil {
+		t.Error("cannot parse config path")
+	}
 	err = backend.Save(c)
 	if err != nil {
 		t.Errorf("Failed to save the config to %s", p)


### PR DESCRIPTION
I've run `golangci-lint` on `cfg` package and it found some violations. Mostly, it comes from `go-lint` and about ignored variables and unchecked errors.

The PR fixes all the violations.