### PR TITLE
Starlark

### DIFF
--- a/beehive.go
+++ b/beehive.go
@@ -38,6 +38,7 @@ import (
 	"github.com/muesli/beehive/app"
 	"github.com/muesli/beehive/cfg"
 	_ "github.com/muesli/beehive/filters"
+	_ "github.com/muesli/beehive/filters/starlark"
 	_ "github.com/muesli/beehive/filters/template"
 
 	"github.com/muesli/beehive/bees"

--- a/bees/actions.go
+++ b/bees/actions.go
@@ -98,6 +98,9 @@ func execAction(action Action, opts map[string]interface{}) bool {
 	}
 
 	bee := GetBee(a.Bee)
+	if bee == nil {
+		log.Fatal("cannot find bee ", a.Bee)
+	}
 	if (*bee).IsRunning() {
 		(*bee).LogAction()
 

--- a/bees/filters.go
+++ b/bees/filters.go
@@ -43,14 +43,18 @@ func execFilter(source string, opts map[string]interface{}) bool {
 		name = "starlark"
 	}
 
-	f := *filters.GetFilter(name)
+	filter := filters.GetFilter(name)
+	if filter == nil {
+		log.Error("cannot find filter", name)
+		return false
+	}
 	log.Println("\tExecuting filter:", source)
 
 	defer func() {
 		if e := recover(); e != nil {
-			log.Println("Fatal filter event:", e)
+			log.Error("Fatal filter event:", e)
 		}
 	}()
 
-	return f.Passes(opts, source)
+	return (*filter).Passes(opts, source)
 }

--- a/bees/filters.go
+++ b/bees/filters.go
@@ -52,7 +52,7 @@ func execFilter(source string, opts map[string]interface{}) bool {
 
 	defer func() {
 		if e := recover(); e != nil {
-			log.Error("Fatal filter event:", e)
+			log.Error("Fatal filter event: ", e)
 		}
 	}()
 

--- a/bees/filters.go
+++ b/bees/filters.go
@@ -40,7 +40,7 @@ type Filter struct {
 func execFilter(source string, opts map[string]interface{}) bool {
 	name := "template"
 	if strings.Contains(source, "def main(") {
-		name := "starlark"
+		name = "starlark"
 	}
 
 	f := *filters.GetFilter(name)

--- a/bees/filters.go
+++ b/bees/filters.go
@@ -22,6 +22,8 @@
 package bees
 
 import (
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/muesli/beehive/filters"
@@ -35,9 +37,14 @@ type Filter struct {
 }
 
 // execFilter executes a filter. Returns whether the filter passed or not.
-func execFilter(filter string, opts map[string]interface{}) bool {
-	f := *filters.GetFilter("template")
-	log.Println("\tExecuting filter:", filter)
+func execFilter(source string, opts map[string]interface{}) bool {
+	name := "template"
+	if strings.Contains(source, "def main(") {
+		name := "starlark"
+	}
+
+	f := *filters.GetFilter(name)
+	log.Println("\tExecuting filter:", source)
 
 	defer func() {
 		if e := recover(); e != nil {
@@ -45,5 +52,5 @@ func execFilter(filter string, opts map[string]interface{}) bool {
 		}
 	}()
 
-	return f.Passes(opts, filter)
+	return f.Passes(opts, source)
 }

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -1,0 +1,41 @@
+# Filters
+
+Whenever an Event occurs, all of the Filters you defined in a Chain get executed with the data the Event provided. Only if the Event passes all of the Filters, the configured Actions in this Chain get then executed.
+
+At the moment, there are 2 different types of filters:
+
++ temmplate
++ starlark
+
+## Template
+
+"Template" filter type uses [text/template](https://golang.org/pkg/text/template/) Go package to execute filters. Beehive exposes in the template a few helper functions and most of the [strings](https://golang.org/pkg/strings/) package functions to make templates more powerful. Also an important thing is that the template for filters should go inside `{{test ...}}`. That's pretty much it.
+
+For example, let's check if `text` contains word "beehive":
+
+```clojure
+{{test Contains (ToLower .text) "beehive"}}
+```
+
+See [Beehive wiki](https://github.com/muesli/beehive/wiki/Filters) for more information.
+
+## Starlark
+
+[Starlark](https://github.com/bazelbuild/starlark) is a dialect of Python created for [Bazel](https://bazel.build/) configuration files. If you know Python, you already know Starlark. To make sure if a syntax feature is supported check [the specification](https://github.com/google/starlark-go/blob/master/doc/spec.md).
+
+Beehive executes `main` function from the filter, passing all variables inside as keyword arguments. The function must return a boolean result.
+
+For example, let's check if title or description of an RSS feed contains any of the given terms:
+
+```python
+def main(title, description, **kwargs):
+    text = title + " " + description
+    text = text.lower()
+    terms = ["beehive", "muesli"]
+    for term in terms:
+        if term in text:
+        return True
+    return False
+```
+
+"Starlark" filters are more verbose that "template" but much more powerful and turing-complete.

--- a/filters/filters.go
+++ b/filters/filters.go
@@ -29,7 +29,7 @@ type FilterInterface interface {
 	Description() string
 
 	// Execute the filter
-	Passes(data interface{}, value interface{}) bool
+	Passes(data map[string]interface{}, value string) bool
 }
 
 var (

--- a/filters/starlark/dedent.go
+++ b/filters/starlark/dedent.go
@@ -1,0 +1,50 @@
+// https://github.com/lithammer/dedent
+package starlarkfilter
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	whitespaceOnly    = regexp.MustCompile("(?m)^[ \t]+$")
+	leadingWhitespace = regexp.MustCompile("(?m)(^[ \t]*)(?:[^ \t\n])")
+)
+
+// Dedent removes any common leading whitespace from every line in text.
+//
+// This can be used to make multiline strings to line up with the left edge of
+// the display, while still presenting them in the source code in indented
+// form.
+func dedent(text string) string {
+	var margin string
+
+	text = whitespaceOnly.ReplaceAllString(text, "")
+	indents := leadingWhitespace.FindAllStringSubmatch(text, -1)
+
+	// Look for the longest leading string of spaces and tabs common to all
+	// lines.
+	for i, indent := range indents {
+		if i == 0 {
+			margin = indent[1]
+		} else if strings.HasPrefix(indent[1], margin) {
+			// Current line more deeply indented than previous winner:
+			// no change (previous winner is still on top).
+			continue
+		} else if strings.HasPrefix(margin, indent[1]) {
+			// Current line consistent with and no deeper than previous winner:
+			// it's the new winner.
+			margin = indent[1]
+		} else {
+			// Current line and previous winner have no common whitespace:
+			// there is no margin.
+			margin = ""
+			break
+		}
+	}
+
+	if margin != "" {
+		text = regexp.MustCompile("(?m)^"+margin).ReplaceAllString(text, "")
+	}
+	return text
+}

--- a/filters/starlark/dedent_test.go
+++ b/filters/starlark/dedent_test.go
@@ -1,0 +1,179 @@
+// https://github.com/lithammer/dedent/blob/master/dedent_test.go
+package starlarkfilter
+
+import (
+	"fmt"
+	"testing"
+)
+
+const errorMsg = "\nexpected %q\ngot %q"
+
+type dedentTest struct {
+	text, expect string
+}
+
+func TestDedentNoMargin(t *testing.T) {
+	texts := []string{
+		// No lines indented
+		"Hello there.\nHow are you?\nOh good, I'm glad.",
+		// Similar with a blank line
+		"Hello there.\n\nBoo!",
+		// Some lines indented, but overall margin is still zero
+		"Hello there.\n  This is indented.",
+		// Again, add a blank line.
+		"Hello there.\n\n  Boo!\n",
+	}
+
+	for _, text := range texts {
+		if text != dedent(text) {
+			t.Errorf(errorMsg, text, dedent(text))
+		}
+	}
+}
+
+func TestDedentEven(t *testing.T) {
+	texts := []dedentTest{
+		{
+			// All lines indented by two spaces
+			text:   "  Hello there.\n  How are ya?\n  Oh good.",
+			expect: "Hello there.\nHow are ya?\nOh good.",
+		},
+		{
+			// Same, with blank lines
+			text:   "  Hello there.\n\n  How are ya?\n  Oh good.\n",
+			expect: "Hello there.\n\nHow are ya?\nOh good.\n",
+		},
+		{
+			// Now indent one of the blank lines
+			text:   "  Hello there.\n  \n  How are ya?\n  Oh good.\n",
+			expect: "Hello there.\n\nHow are ya?\nOh good.\n",
+		},
+	}
+
+	for _, text := range texts {
+		if text.expect != dedent(text.text) {
+			t.Errorf(errorMsg, text.expect, dedent(text.text))
+		}
+	}
+}
+
+func TestDedentUneven(t *testing.T) {
+	texts := []dedentTest{
+		{
+			// Lines indented unevenly
+			text: `
+			def foo():
+				while 1:
+					return foo
+			`,
+			expect: `
+def foo():
+	while 1:
+		return foo
+`,
+		},
+		{
+			// Uneven indentation with a blank line
+			text:   "  Foo\n    Bar\n\n   Baz\n",
+			expect: "Foo\n  Bar\n\n Baz\n",
+		},
+		{
+			// Uneven indentation with a whitespace-only line
+			text:   "  Foo\n    Bar\n \n   Baz\n",
+			expect: "Foo\n  Bar\n\n Baz\n",
+		},
+	}
+
+	for _, text := range texts {
+		if text.expect != dedent(text.text) {
+			t.Errorf(errorMsg, text.expect, dedent(text.text))
+		}
+	}
+}
+
+// dedent() should not mangle internal tabs.
+func TestDedentPreserveInternalTabs(t *testing.T) {
+	text := "  hello\tthere\n  how are\tyou?"
+	expect := "hello\tthere\nhow are\tyou?"
+	if expect != dedent(text) {
+		t.Errorf(errorMsg, expect, dedent(text))
+	}
+
+	// Make sure that it preserves tabs when it's not making any changes at all
+	if expect != dedent(expect) {
+		t.Errorf(errorMsg, expect, dedent(expect))
+	}
+}
+
+// dedent() should not mangle tabs in the margin (i.e. tabs and spaces both
+// count as margin, but are *not* considered equivalent).
+func TestDedentPreserveMarginTabs(t *testing.T) {
+	texts := []string{
+		"  hello there\n\thow are you?",
+		// Same effect even if we have 8 spaces
+		"        hello there\n\thow are you?",
+	}
+
+	for _, text := range texts {
+		d := dedent(text)
+		if text != d {
+			t.Errorf(errorMsg, text, d)
+		}
+	}
+
+	texts2 := []dedentTest{
+		{
+			// dedent() only removes whitespace that can be uniformly removed!
+			text:   "\thello there\n\thow are you?",
+			expect: "hello there\nhow are you?",
+		},
+		{
+			text:   "  \thello there\n  \thow are you?",
+			expect: "hello there\nhow are you?",
+		},
+		{
+			text:   "  \t  hello there\n  \t  how are you?",
+			expect: "hello there\nhow are you?",
+		},
+		{
+			text:   "  \thello there\n  \t  how are you?",
+			expect: "hello there\n  how are you?",
+		},
+	}
+
+	for _, text := range texts2 {
+		if text.expect != dedent(text.text) {
+			t.Errorf(errorMsg, text.expect, dedent(text.text))
+		}
+	}
+}
+
+func Examplededent() {
+	s := `
+		Lorem ipsum dolor sit amet,
+		consectetur adipiscing elit.
+		Curabitur justo tellus, facilisis nec efficitur dictum,
+		fermentum vitae ligula. Sed eu convallis sapien.`
+	fmt.Println(dedent(s))
+	fmt.Println("-------------")
+	fmt.Println(s)
+	// Output:
+	// Lorem ipsum dolor sit amet,
+	// consectetur adipiscing elit.
+	// Curabitur justo tellus, facilisis nec efficitur dictum,
+	// fermentum vitae ligula. Sed eu convallis sapien.
+	// -------------
+	//
+	//		Lorem ipsum dolor sit amet,
+	//		consectetur adipiscing elit.
+	//		Curabitur justo tellus, facilisis nec efficitur dictum,
+	//		fermentum vitae ligula. Sed eu convallis sapien.
+}
+
+func BenchmarkDedent(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		dedent(`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+		Curabitur justo tellus, facilisis nec efficitur dictum,
+		fermentum vitae ligula. Sed eu convallis sapien.`)
+	}
+}

--- a/filters/starlark/starlarkfilter.go
+++ b/filters/starlark/starlarkfilter.go
@@ -1,0 +1,73 @@
+// Package templatefilter provides a starlark-based filter.
+// https://github.com/google/starlark-go
+package starlarkfilter
+
+import (
+	"github.com/muesli/beehive/filters"
+	"go.starlark.net/starlark"
+)
+
+// StarlarkFilter is a starlark-based filter.
+// https://github.com/google/starlark-go
+type StarlarkFilter struct {
+}
+
+// Name returns the name of this Filter.
+func (filter *StarlarkFilter) Name() string {
+	return "starlark"
+}
+
+// Description returns the description of this Filter.
+func (filter *StarlarkFilter) Description() string {
+	return "This filter passes when `main` function returns True"
+}
+
+func (filter *StarlarkFilter) convert(v interface{}) starlark.Value {
+	switch val := v.(type) {
+	case string:
+		return starlark.String(val)
+	case bool:
+		return starlark.Bool(val)
+	case int:
+		return starlark.MakeInt(val)
+	case []interface{}:
+		vals := make([]starlark.Value, len(val))
+		for i, el := range val {
+			vals[i] = filter.convert(el)
+		}
+		return starlark.NewList(vals)
+	}
+	panic("unknown type")
+}
+
+// Passes returns true when the Filter matched the opts.
+func (filter *StarlarkFilter) Passes(opts map[string]interface{}, template string) bool {
+	template = dedent(template)
+	thread := &starlark.Thread{Name: "main thread"}
+	globals, err := starlark.ExecFile(thread, "template.star", template, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	kwargs := make([]starlark.Tuple, 0)
+	for key, value := range opts {
+		arg := starlark.Tuple([]starlark.Value{
+			starlark.String(key),
+			filter.convert(value),
+		})
+		kwargs = append(kwargs, arg)
+	}
+
+	main := globals["main"]
+	result, err := starlark.Call(thread, main, nil, kwargs)
+	if err != nil {
+		panic(err)
+	}
+	return bool(result.Truth())
+}
+
+func init() {
+	f := StarlarkFilter{}
+
+	filters.RegisterFilter(&f)
+}

--- a/filters/starlark/starlarkfilter.go
+++ b/filters/starlark/starlarkfilter.go
@@ -25,25 +25,49 @@ func (filter *StarlarkFilter) Description() string {
 	return "This filter passes when `main` function returns True"
 }
 
-func (filter *StarlarkFilter) convert(reflected reflect.Value) starlark.Value {
+func (filter *StarlarkFilter) convert(reflected reflect.Value) (starlark.Value, error) {
+	var err error
 	switch reflected.Kind() {
 	case reflect.Bool:
-		return starlark.Bool(reflected.Bool())
+		return starlark.Bool(reflected.Bool()), nil
 	case reflect.String:
-		return starlark.String(reflected.String())
+		return starlark.String(reflected.String()), nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return starlark.MakeInt64(reflected.Int())
+		return starlark.MakeInt64(reflected.Int()), nil
 	case reflect.Slice:
 		count := reflected.Len()
 		vals := make([]starlark.Value, count)
 		for i := 0; i < count; i++ {
 			el := reflected.Index(i)
-			vals[i] = filter.convert(el)
+			vals[i], err = filter.convert(el)
+			if err != nil {
+				return nil, err
+			}
 		}
-		return starlark.NewList(vals)
-	default:
-		panic(fmt.Sprintf("unknown type: %s", reflected.Kind()))
+		return starlark.NewList(vals), nil
+	case reflect.Map:
+		result := starlark.NewDict(reflected.Len())
+		iter := reflected.MapRange()
+		for iter.Next() {
+			key, err := filter.convert(iter.Key())
+			if err != nil {
+				return nil, err
+			}
+			value, err := filter.convert(iter.Value())
+			if err != nil {
+				return nil, err
+			}
+			err = result.SetKey(key, value)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return result, nil
 	}
+	if err != nil {
+		return nil, err
+	}
+	return nil, fmt.Errorf("unknown type: %s", reflected.Kind())
 }
 
 // Passes returns true when the Filter matched the opts.
@@ -57,10 +81,11 @@ func (filter *StarlarkFilter) Passes(opts map[string]interface{}, template strin
 
 	kwargs := make([]starlark.Tuple, 0)
 	for key, value := range opts {
-		arg := starlark.Tuple([]starlark.Value{
-			starlark.String(key),
-			filter.convert(reflect.ValueOf(value)),
-		})
+		converted, err := filter.convert(reflect.ValueOf(value))
+		if err != nil {
+			panic(err)
+		}
+		arg := starlark.Tuple([]starlark.Value{starlark.String(key), converted})
 		kwargs = append(kwargs, arg)
 	}
 

--- a/filters/starlark/starlarkfilter.go
+++ b/filters/starlark/starlarkfilter.go
@@ -63,6 +63,8 @@ func (filter *StarlarkFilter) convert(reflected reflect.Value) (starlark.Value, 
 			}
 		}
 		return result, nil
+	case reflect.Ptr:
+		return filter.convert(reflected.Elem())
 	}
 	if err != nil {
 		return nil, err

--- a/filters/starlark/starlarkfilter.go
+++ b/filters/starlark/starlarkfilter.go
@@ -1,8 +1,9 @@
-// Package templatefilter provides a starlark-based filter.
+// Package starlarkfilter provides a starlark-based filter.
 // https://github.com/google/starlark-go
 package starlarkfilter
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/muesli/beehive/filters"
@@ -40,8 +41,9 @@ func (filter *StarlarkFilter) convert(reflected reflect.Value) starlark.Value {
 			vals[i] = filter.convert(el)
 		}
 		return starlark.NewList(vals)
+	default:
+		panic(fmt.Sprintf("unknown type: %s", reflected.Kind()))
 	}
-	panic("unknown type")
 }
 
 // Passes returns true when the Filter matched the opts.
@@ -72,6 +74,5 @@ func (filter *StarlarkFilter) Passes(opts map[string]interface{}, template strin
 
 func init() {
 	f := StarlarkFilter{}
-
 	filters.RegisterFilter(&f)
 }

--- a/filters/starlark/starlarkfilter_test.go
+++ b/filters/starlark/starlarkfilter_test.go
@@ -56,6 +56,13 @@ func TestStarlarkFilter(t *testing.T) {
 		t.Error("[text in map] must be false but it is not")
 	}
 
+	// test pointer convertion
+	items := map[string]bool{"oh": true, "hi": true, "mark": true}
+	o["items"] = &items
+	if !f.Passes(o, template) {
+		t.Error("[text in map] must be true but it is not")
+	}
+
 	// test bool convertion
 	template = `
 	def main(res, **kwargs):

--- a/filters/starlark/starlarkfilter_test.go
+++ b/filters/starlark/starlarkfilter_test.go
@@ -1,0 +1,25 @@
+package starlarkfilter
+
+import (
+	"testing"
+)
+
+func TestStarlarkFilter(t *testing.T) {
+	f := StarlarkFilter{}
+
+	o := map[string]interface{}{}
+	template := `
+	def main(text):
+		return text == 'good'
+	`
+
+	o["text"] = "good"
+	if !f.Passes(o, template) {
+		t.Error("must be true but it is not")
+	}
+
+	o["text"] = "not-good"
+	if f.Passes(o, template) {
+		t.Error("must be false but it is not")
+	}
+}

--- a/filters/starlark/starlarkfilter_test.go
+++ b/filters/starlark/starlarkfilter_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestStarlarkFilter(t *testing.T) {
+	t.Parallel()
 	f := StarlarkFilter{}
 
 	o := map[string]interface{}{}
@@ -13,21 +14,23 @@ func TestStarlarkFilter(t *testing.T) {
 		return text == 'good'
 	`
 
+	// test string convertion
 	o["text"] = "good"
 	if !f.Passes(o, template) {
 		t.Error("must be true but it is not")
 	}
-
 	o["text"] = "not-good"
 	if f.Passes(o, template) {
 		t.Error("must be false but it is not")
 	}
 
+	// test int convertion
 	o["text"] = 1
 	if f.Passes(o, template) {
 		t.Error("must be false but it is not")
 	}
 
+	// test slice convertion
 	template = `
 	def main(text, items):
 		return text in items
@@ -42,6 +45,18 @@ func TestStarlarkFilter(t *testing.T) {
 		t.Error("[text in items] must be false but it is not")
 	}
 
+	// test map convertion
+	o["text"] = "hi"
+	o["items"] = map[string]bool{"oh": true, "hi": true, "mark": true}
+	if !f.Passes(o, template) {
+		t.Error("[text in map] must be true but it is not")
+	}
+	o["items"] = map[string]bool{"oh": true, "hello": true, "mark": true}
+	if f.Passes(o, template) {
+		t.Error("[text in map] must be false but it is not")
+	}
+
+	// test bool convertion
 	template = `
 	def main(res, **kwargs):
 		return res

--- a/filters/starlark/starlarkfilter_test.go
+++ b/filters/starlark/starlarkfilter_test.go
@@ -27,4 +27,31 @@ func TestStarlarkFilter(t *testing.T) {
 	if f.Passes(o, template) {
 		t.Error("must be false but it is not")
 	}
+
+	template = `
+	def main(text, items):
+		return text in items
+	`
+	o["items"] = []string{"oh", "hi", "mark"}
+	o["text"] = "hi"
+	if !f.Passes(o, template) {
+		t.Error("[text in items] must be true but it is not")
+	}
+	o["text"] = "hello"
+	if f.Passes(o, template) {
+		t.Error("[text in items] must be false but it is not")
+	}
+
+	template = `
+	def main(res, **kwargs):
+		return res
+	`
+	o["res"] = true
+	if !f.Passes(o, template) {
+		t.Error("[identity] must be true but it is not")
+	}
+	o["res"] = false
+	if f.Passes(o, template) {
+		t.Error("[identity] must be false but it is not")
+	}
 }

--- a/filters/starlark/starlarkfilter_test.go
+++ b/filters/starlark/starlarkfilter_test.go
@@ -22,4 +22,9 @@ func TestStarlarkFilter(t *testing.T) {
 	if f.Passes(o, template) {
 		t.Error("must be false but it is not")
 	}
+
+	o["text"] = 1
+	if f.Passes(o, template) {
+		t.Error("must be false but it is not")
+	}
 }

--- a/filters/template/templatefilter.go
+++ b/filters/template/templatefilter.go
@@ -45,28 +45,23 @@ func (filter *TemplateFilter) Description() string {
 }
 
 // Passes returns true when the Filter matched the data.
-func (filter *TemplateFilter) Passes(data interface{}, value interface{}) bool {
-	switch v := value.(type) {
-	case string:
-		var res bytes.Buffer
+func (filter *TemplateFilter) Passes(data map[string]interface{}, v string) bool {
+	var res bytes.Buffer
 
-		if strings.Index(v, "{{test") >= 0 {
-			v = strings.Replace(v, "{{test", "{{if", -1)
-			v += "true{{end}}"
-		}
-
-		tmpl, err := template.New("_" + v).Funcs(templatehelper.FuncMap).Parse(v)
-		if err == nil {
-			err = tmpl.Execute(&res, data)
-		}
-		if err != nil {
-			panic(err)
-		}
-
-		return strings.TrimSpace(res.String()) == "true"
+	if strings.Contains(v, "{{test") {
+		v = strings.Replace(v, "{{test", "{{if", -1)
+		v += "true{{end}}"
 	}
 
-	return false
+	tmpl, err := template.New("_" + v).Funcs(templatehelper.FuncMap).Parse(v)
+	if err == nil {
+		err = tmpl.Execute(&res, data)
+	}
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.TrimSpace(res.String()) == "true"
 }
 
 func init() {

--- a/filters/template/templatefilter.go
+++ b/filters/template/templatefilter.go
@@ -66,6 +66,5 @@ func (filter *TemplateFilter) Passes(data map[string]interface{}, v string) bool
 
 func init() {
 	f := TemplateFilter{}
-
 	filters.RegisterFilter(&f)
 }

--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 // indirect
+	go.starlark.net v0.0.0-20201006213952-227f4aabceb5
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,9 @@ github.com/bwmarrin/discordgo v0.19.0 h1:kMED/DB0NR1QhRcalb85w0Cu3Ep2OrGAqZH1R5a
 github.com/bwmarrin/discordgo v0.19.0/go.mod h1:O9S4p+ofTFwB02em7jkpkV8M3R0/PUVOwN61zSZ0r4Q=
 github.com/carlosdp/twiliogo v0.0.0-20161027183705-b26045ebb9d1 h1:hXakhQtPnXH839q1pBl/GqfTSchqE+R5Fqn98Iu7UQM=
 github.com/carlosdp/twiliogo v0.0.0-20161027183705-b26045ebb9d1/go.mod h1:pAxCBpjl/0JxYZlWGP/Dyi8f/LQSCQD2WAsG/iNzqQ8=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cloudflare/cloudflare-go v0.10.6 h1:mbv0IrcrrLlPLxAzCdW6aQ/CPlqhyXrXTjviU0Tb+34=
 github.com/cloudflare/cloudflare-go v0.10.6/go.mod h1:dcRl7AXBH5Bf7QFTBVc3TRzwvotSeO4AlnMhuxORAX8=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
@@ -255,6 +258,8 @@ github.com/wcharczuk/go-chart v2.0.1+incompatible h1:0pz39ZAycJFF7ju/1mepnk26RLV
 github.com/wcharczuk/go-chart v2.0.1+incompatible/go.mod h1:PF5tmL4EIx/7Wf+hEkpCqYi5He4u90sw+0+6FhrryuE=
 github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9 h1:w8V9v0qVympSF6GjdjIyeqR7+EVhAF9CBQmkmW7Zw0w=
 github.com/xrash/smetrics v0.0.0-20170218160415-a3153f7040e9/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
+go.starlark.net v0.0.0-20201006213952-227f4aabceb5 h1:ApvY/1gw+Yiqb/FKeks3KnVPWpkR3xzij82XPKLjJVw=
+go.starlark.net v0.0.0-20201006213952-227f4aabceb5/go.mod h1:f0znQkUKRrkk36XxWbGjMqQM8wGv/xHBVE2qc3B5oFU=
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -286,6 +291,8 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
+golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
Add [Starlark](https://github.com/google/starlark-go) template filter syntax support. See the included documentation for more information

## Motivation

1. More powerful: everything that we can do with "template" filters can be done with "starlark" and much more. Actually, Starlark is turing-complete.
1. More readable.
1. Familiar: Python is one of the most popular languages.

## Requirements

Blocked by #340 (contains that PR in the diff)

## TODO

The `input` field for filters in [beehive-admin](https://github.com/muesli/beehive-admin) should be changed to `textarea`. For now, I'm using YAML configuration file from #339 to write starlark filters.
