### PR TITLE
Fix Twitter 100% CPU (#335)

### DIFF
--- a/bees/twitterbee/twitterbee.go
+++ b/bees/twitterbee/twitterbee.go
@@ -292,6 +292,7 @@ func (mod *TwitterBee) handleStream() {
 			return
 		case item := <-s.C:
 			mod.handleStreamEvent(item)
+			time.Sleep(time.Second)
 		}
 	}
 }


### PR DESCRIPTION
This fixes the 100% CPU problem of https://github.com/muesli/beehive/issues/335.

- Posting a tweet still works
- Reacting to a like still doesn't work