### PR TITLE
Introduce skip_first_allow_newest setting for RSS bee

### DIFF
--- a/bees/rssbee/rssbee.go
+++ b/bees/rssbee/rssbee.go
@@ -39,6 +39,9 @@ type RSSBee struct {
 	// decides whether the next fetch should be skipped
 	skipNextFetch bool
 
+	// decides whether only the newest item from the next fetch should to get through
+	skipNextFetchAllowNewest bool
+
 	eventChan chan bees.Event
 }
 
@@ -130,6 +133,12 @@ func (mod *RSSBee) itemHandler(feed *rss.Feed, ch *rss.Channel, newitems []*rss.
 		}
 
 		mod.eventChan <- newitemEvent
+
+		if mod.skipNextFetchAllowNewest == true {
+			// the first time only let the newest item pass
+			mod.skipNextFetchAllowNewest = false
+			break
+		}
 	}
 	mod.Logf("%d new item(s) in %s", len(newitems), feed.Url)
 }
@@ -166,5 +175,6 @@ func (mod *RSSBee) ReloadOptions(options bees.BeeOptions) {
 	mod.SetOptions(options)
 
 	options.Bind("skip_first", &mod.skipNextFetch)
+	options.Bind("skip_first_allow_newest", &mod.skipNextFetchAllowNewest)
 	options.Bind("url", &mod.url)
 }

--- a/bees/rssbee/rssbee.go
+++ b/bees/rssbee/rssbee.go
@@ -50,7 +50,7 @@ func (mod *RSSBee) chanHandler(feed *rss.Feed, newchannels []*rss.Channel) {
 }
 
 func (mod *RSSBee) itemHandler(feed *rss.Feed, ch *rss.Channel, newitems []*rss.Item) {
-	if mod.skipNextFetch == true || mod.skipNextFetchAllowNewest {
+	if mod.skipNextFetch == true || mod.skipNextFetchAllowNewest == true {
 		mod.skipNextFetch = false
 		return
 	}

--- a/bees/rssbee/rssbee.go
+++ b/bees/rssbee/rssbee.go
@@ -50,7 +50,7 @@ func (mod *RSSBee) chanHandler(feed *rss.Feed, newchannels []*rss.Channel) {
 }
 
 func (mod *RSSBee) itemHandler(feed *rss.Feed, ch *rss.Channel, newitems []*rss.Item) {
-	if mod.skipNextFetch == true {
+	if mod.skipNextFetch == true || mod.skipNextFetchAllowNewest {
 		mod.skipNextFetch = false
 		return
 	}

--- a/bees/rssbee/rssbeefactory.go
+++ b/bees/rssbee/rssbeefactory.go
@@ -80,6 +80,13 @@ func (factory *RSSBeeFactory) Options() []bees.BeeOptionDescriptor {
 			Mandatory:   false,
 			Default:     false,
 		},
+		{
+			Name:        "skip_first_allow_newest",
+			Description: "Whether to skip already existing entries, but allow the newest item to get through once",
+			Type:        "bool",
+			Mandatory:   false,
+			Default:     false,
+		},
 	}
 	return opts
 }


### PR DESCRIPTION
@muesli, this would allow the user to tell the bee to skip all current rss items, but allow the newest item to get through once. This way you are able to try to send posts that were triggered by RSS again if there was a problem with the destination bee.