### PR TITLE
githubbee - Add support of the release event

### DIFF
--- a/bees/githubbee/events.go
+++ b/bees/githubbee/events.go
@@ -30,6 +30,59 @@ import (
 	"github.com/muesli/beehive/bees"
 )
 
+func (mod *GitHubBee) handleReleaseEvent(event *github.Event) {
+	var b github.ReleaseEvent
+	json.Unmarshal(*event.RawPayload, &b)
+
+	ev := bees.Event{
+		Bee:  mod.Name(),
+		Name: "release",
+		Options: []bees.Placeholder{
+			{
+				Name:  "public",
+				Type:  "bool",
+				Value: *event.Public,
+			},
+			{
+				Name:  "repo",
+				Type:  "string",
+				Value: *event.Repo.Name,
+			},
+			{
+				Name:  "repo_url",
+				Type:  "url",
+				Value: "https://github.com/" + *event.Repo.Name,
+			},
+			{
+				Name:  "username",
+				Type:  "string",
+				Value: *event.Actor.Login,
+			},
+			{
+				Name:  "event_id",
+				Type:  "string",
+				Value: *event.ID,
+			},
+			{
+				Name:  "release_title",
+				Type:  "string",
+				Value: *b.Release.Name,
+			},
+			{
+				Name:  "release_tag_version",
+				Type:  "string",
+				Value: *b.Release.TagName,
+			},
+			{
+				Name:  "release_description",
+				Type:  "string",
+				Value: *b.Release.Body,
+			},
+		},
+	}
+	mod.eventChan <- ev
+}
+
 func (mod *GitHubBee) handlePushEvent(event *github.Event) {
 	var b github.PushEvent
 	json.Unmarshal(*event.RawPayload, &b)

--- a/bees/githubbee/events.go
+++ b/bees/githubbee/events.go
@@ -64,17 +64,17 @@ func (mod *GitHubBee) handleReleaseEvent(event *github.Event) {
 				Value: *event.ID,
 			},
 			{
-				Name:  "release_title",
+				Name:  "title",
 				Type:  "string",
 				Value: *b.Release.Name,
 			},
 			{
-				Name:  "release_tag_version",
+				Name:  "tag_version",
 				Type:  "string",
 				Value: *b.Release.TagName,
 			},
 			{
-				Name:  "release_description",
+				Name:  "description",
 				Type:  "string",
 				Value: *b.Release.Body,
 			},

--- a/bees/githubbee/githubbee.go
+++ b/bees/githubbee/githubbee.go
@@ -151,6 +151,8 @@ func (mod *GitHubBee) getRepositoryEvents(owner, repo string, since time.Time) {
 				mod.handlePullRequestEvent(v)
 			case "PullRequestReviewCommentEvent":
 				mod.handlePullRequestReviewCommentEvent(v)
+			case "ReleaseEvent":
+				mod.handleReleaseEvent(v)
 
 			default:
 				mod.LogErrorf("Unhandled event: %s", *v.Type)

--- a/bees/githubbee/githubbeefactory.go
+++ b/bees/githubbee/githubbeefactory.go
@@ -509,6 +509,53 @@ func (factory *GitHubBeeFactory) Events() []bees.EventDescriptor {
 				},
 			},
 		},
+		{
+			Namespace:   factory.Name(),
+			Name:        "release",
+			Description: "A new release has been published",
+			Options: []bees.PlaceholderDescriptor{
+				{
+					Name:        "public",
+					Description: "Indicates whether this was a public activity",
+					Type:        "string",
+				},
+				{
+					Name:        "repo",
+					Description: "The repository that the release belongs to",
+					Type:        "string",
+				},
+				{
+					Name:        "repo_url",
+					Description: "The repository's URL",
+					Type:        "url",
+				},
+				{
+					Name:        "username",
+					Description: "Username that published the release",
+					Type:        "string",
+				},
+				{
+					Name:        "event_id",
+					Description: "ID of the GitHub event",
+					Type:        "string",
+				},
+				{
+					Name:        "release_title",
+					Description: "The release title",
+					Type:        "string",
+				},
+				{
+					Name:        "release_tag_version",
+					Description: "The release tag version",
+					Type:        "string",
+				},
+				{
+					Name:        "release_description",
+					Description: "The release description",
+					Type:        "string",
+				},
+			},
+		},
 	}
 	return events
 }

--- a/bees/githubbee/githubbeefactory.go
+++ b/bees/githubbee/githubbeefactory.go
@@ -540,17 +540,17 @@ func (factory *GitHubBeeFactory) Events() []bees.EventDescriptor {
 					Type:        "string",
 				},
 				{
-					Name:        "release_title",
+					Name:        "title",
 					Description: "The release title",
 					Type:        "string",
 				},
 				{
-					Name:        "release_tag_version",
+					Name:        "tag_version",
 					Description: "The release tag version",
 					Type:        "string",
 				},
 				{
-					Name:        "release_description",
+					Name:        "description",
 					Description: "The release description",
 					Type:        "string",
 				},


### PR DESCRIPTION
As per request in the issue https://github.com/muesli/beehive/issues/318, I added the support of the release events in the Github Bee.