### PR TITLE
MastodonBee - Account mapping fix and enhancement in events

### DIFF
--- a/bees/mastodonbee/events.go
+++ b/bees/mastodonbee/events.go
@@ -109,7 +109,17 @@ func (mod *MastodonBee) handleNotification(notif *mastodon.Notification) {
 				},
 				{
 					Name:  "username",
+					Value: notif.Account.Username,
+					Type:  "string",
+				},
+				{
+					Name:  "display_name",
 					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "acct",
+					Value: notif.Account.Acct,
 					Type:  "string",
 				},
 				{
@@ -153,7 +163,17 @@ func (mod *MastodonBee) handleNotification(notif *mastodon.Notification) {
 				},
 				{
 					Name:  "username",
+					Value: notif.Account.Username,
+					Type:  "string",
+				},
+				{
+					Name:  "display_name",
 					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "acct",
+					Value: notif.Account.Acct,
 					Type:  "string",
 				},
 				{
@@ -187,7 +207,17 @@ func (mod *MastodonBee) handleNotification(notif *mastodon.Notification) {
 				},
 				{
 					Name:  "username",
-					Value: notif.Status.Account.DisplayName,
+					Value: notif.Account.Username,
+					Type:  "string",
+				},
+				{
+					Name:  "display_name",
+					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "acct",
+					Value: notif.Account.Acct,
 					Type:  "string",
 				},
 				{
@@ -226,7 +256,17 @@ func (mod *MastodonBee) handleNotification(notif *mastodon.Notification) {
 				},
 				{
 					Name:  "username",
-					Value: notif.Status.Account.DisplayName,
+					Value: notif.Account.Username,
+					Type:  "string",
+				},
+				{
+					Name:  "display_name",
+					Value: notif.Account.DisplayName,
+					Type:  "string",
+				},
+				{
+					Name:  "acct",
+					Value: notif.Account.Acct,
 					Type:  "string",
 				},
 				{

--- a/bees/mastodonbee/mastodonbeefactory.go
+++ b/bees/mastodonbee/mastodonbeefactory.go
@@ -175,7 +175,17 @@ func (factory *MastodonBeeFactory) Events() []bees.EventDescriptor {
 				},
 				{
 					Name:        "username",
-					Description: "Mastodon handle of the user which triggered the follow event",
+					Description: "Mastodon username of the user which triggered the follow event",
+					Type:        "string",
+				},
+				{
+					Name:        "display_name",
+					Description: "Mastodon display name of the user which triggered the follow event",
+					Type:        "string",
+				},
+				{
+					Name:        "acct",
+					Description: "Mastodon account of the user which triggered the follow event",
 					Type:        "string",
 				},
 				{
@@ -266,7 +276,17 @@ func (factory *MastodonBeeFactory) Events() []bees.EventDescriptor {
 				},
 				{
 					Name:        "username",
-					Description: "The Mastodon handle of the user that favourited your toot",
+					Description: "The Mastodon username of the user that favourited your toot",
+					Type:        "string",
+				},
+				{
+					Name:        "display_name",
+					Description: "The Mastodon display name of the user that favourited your toot",
+					Type:        "string",
+				},
+				{
+					Name:        "acct",
+					Description: "The Mastodon account of the user that favourited your toot",
 					Type:        "string",
 				},
 				{
@@ -335,7 +355,17 @@ func (factory *MastodonBeeFactory) Events() []bees.EventDescriptor {
 				},
 				{
 					Name:        "username",
-					Description: "Mastodon handle of the user that reblogged your toot",
+					Description: "Mastodon username of the user that reblogged your toot",
+					Type:        "string",
+				},
+				{
+					Name:        "display_name",
+					Description: "Mastodon display name of the user that reblogged your toot",
+					Type:        "string",
+				},
+				{
+					Name:        "acct",
+					Description: "Mastodon account of the user that reblogged your toot",
 					Type:        "string",
 				},
 				{
@@ -404,7 +434,17 @@ func (factory *MastodonBeeFactory) Events() []bees.EventDescriptor {
 				},
 				{
 					Name:        "username",
-					Description: "The Mastodon handle of the mention's author",
+					Description: "The Mastodon username of the mention's author",
+					Type:        "string",
+				},
+				{
+					Name:        "display_name",
+					Description: "The Mastodon display_name of the mention's author",
+					Type:        "string",
+				},
+				{
+					Name:        "acct",
+					Description: "The Mastodon account of the mention's author",
 					Type:        "string",
 				},
 				{


### PR DESCRIPTION
- Fixed account mapping for **reblog** and **mention** events.
   - Used `notif.Account` instead of `notif.Status.Account`
- Extended **follow**, **favourite**, **reblog** and **mention** events with two new fields `display_name` and `acct` respectively mapped to the same mastodon API fields
- breaking modification (to be consistent with Mastodon API) on **follow**, **favourite**, **reblog** and **mention** events: 
    - re-mapped `username` from mastodon  API field`display_name` to mastodon API field `username`.
    
Solve issue: https://github.com/muesli/beehive/issues/356