### PR TITLE
Don't ignore write events

### DIFF
--- a/bees/fsnotifybee/fsnotifybee.go
+++ b/bees/fsnotifybee/fsnotifybee.go
@@ -49,7 +49,7 @@ func (mod *FSNotifyBee) Run(eventChan chan bees.Event) {
 		case <-mod.SigChan:
 			return
 		case event := <-watcher.Events:
-			if event.Op != fsnotify.Write && event.Op != 0 {
+			if event.Op != 0 {
 				sendEvent(mod.Name(), event.Op.String(), event.Name, eventChan)
 			}
 		case <-watcher.Errors:

--- a/bees/fsnotifybee/fsnotifybee.go
+++ b/bees/fsnotifybee/fsnotifybee.go
@@ -52,7 +52,8 @@ func (mod *FSNotifyBee) Run(eventChan chan bees.Event) {
 			if event.Op != 0 {
 				sendEvent(mod.Name(), event.Op.String(), event.Name, eventChan)
 			}
-		case <-watcher.Errors:
+		case err := <-watcher.Errors:
+			mod.LogErrorf("error received: %s", err)
 		}
 	}
 }


### PR DESCRIPTION
I wondered why `cat >>test.txt` did not generate a `fsnotify` event.